### PR TITLE
Shell script fixups

### DIFF
--- a/lib/agenda.rb
+++ b/lib/agenda.rb
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Mutable object for determining what to do with a shipment
+class Agenda
+  def initialize(shipment, stages)
+    @shipment = shipment
+    @stages = stages
+  end
+
+  def contains?(barcode)
+    true
+  end
+end
+
+class DefaultAgenda < Agenda
+
+  def contains?(barcode)
+    true
+  end
+end

--- a/lib/pagination_check.rb
+++ b/lib/pagination_check.rb
@@ -5,13 +5,13 @@ require 'stage'
 
 # Pagination Stage
 class PaginationCheck < Stage
-  def run
+  def run(agenda = shipment.barcodes)
     @re = /^([0-9]{8})\.(?:tif|jp2)$/
-    barcode_directories.each_with_index do |barcode, i|
+    agenda.each_with_index do |barcode, i|
       write_progress(i, barcode_directories.count, barcode)
       find_errors_in_dir(barcode)
     end
-    write_progress(barcode_directories.count, barcode_directories.count)
+    write_progress(agenda.count, agenda.count)
   end
 
   private

--- a/lib/postflight.rb
+++ b/lib/postflight.rb
@@ -7,22 +7,24 @@ require 'stage'
 
 # Image Metadata Validation Stage
 class Postflight < Stage
-  def run
-    process_shipment_directory
+  def run(agenda = shipment.barcodes)
+    process_shipment_directory agenda
   end
 
   private
 
-  def process_shipment_directory # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def process_shipment_directory(agenda) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     real_barcodes = []
     barcode_directories.each_with_index do |path, i|
       barcode = path.split(File::SEPARATOR)[-1]
+      real_barcodes << barcode
+      unless agenda.include? barcode
+        write_progress(i, barcode_directories.count, "#{barcode} skipped")
+        next
+      end
       write_progress(i, barcode_directories.count + 2,
                      "feed validate #{barcode}")
-      if File.directory? path
-        process_barcode_directory(path, barcode)
-        real_barcodes << barcode
-      end
+      process_barcode_directory(path, barcode)
     end
     write_progress(barcode_directories.count, barcode_directories.count + 2,
                    'barcode check')

--- a/lib/preflight.rb
+++ b/lib/preflight.rb
@@ -20,7 +20,7 @@ class Preflight < Stage
        checksum.md5 prodnote.tif]
   end
 
-  def run # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def run(_agenda = shipment.barcodes) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     shipment.metadata[:initial_barcodes] = []
     validate_shipment_directory
     if shipment.metadata[:initial_barcodes].none?

--- a/lib/processor.rb
+++ b/lib/processor.rb
@@ -23,7 +23,7 @@ class Processor # rubocop:disable Metrics/ClassLength
     stages
   end
 
-  def run # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+  def run
     # Bail out with a message if any previous stage had an error.
     discard_failure if @options[:reset]
     if @options[:restart_all] && File.directory?(@shipment.source_directory)
@@ -65,7 +65,6 @@ class Processor # rubocop:disable Metrics/ClassLength
   def stages
     return @stages unless @stages.nil?
 
-    
     @stages = []
     config[:stages].each do |s|
       require s[:file]
@@ -122,6 +121,7 @@ class Processor # rubocop:disable Metrics/ClassLength
   end
 
   def stage_status(stage)
+    raise "DON'T CALL stage_status ANY MORE"
     @status[:stages][stage.name.to_sym]
   end
 
@@ -149,7 +149,7 @@ class Processor # rubocop:disable Metrics/ClassLength
     stage_status(stage)[:errors].uniq(&:barcode)
   end
 
-  def error_query # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+  def error_query # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
     eq = {}
     (@status[:metadata][:barcodes] + [nil]).each do |b|
       stages.each do |stage|
@@ -169,10 +169,7 @@ class Processor # rubocop:disable Metrics/ClassLength
     (@status[:metadata][:barcodes] + [nil]).each do |b|
       stages.each do |stage|
         next if stage_status(stage).nil?
-        if stage_status(stage)[:warnings].nil?
-          require 'byebug'
-          byebug
-        end
+
         warns = stage_status(stage)[:warnings].select { |e| e.barcode == b }
         next if warns.nil? || warns.none?
 

--- a/lib/shipment.rb
+++ b/lib/shipment.rb
@@ -77,8 +77,6 @@ class Shipment
     path.split(File::SEPARATOR)[-2..].join(File::SEPARATOR)
   end
 
-  # Think twice about trying to memoize this.
-  # Compression will change the names of image files if not the quantity.
   def image_files(type = 'tif')
     files = []
     barcodes.each do |b|

--- a/lib/stage.rb
+++ b/lib/stage.rb
@@ -1,61 +1,83 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require 'json'
 require 'tempfile'
+#require 'time'
 require 'error'
 
 # Base class for conversion stages
 class Stage # rubocop:disable Metrics/ClassLength
-  attr_reader :data
-  attr_accessor :name, :shipment
+  attr_reader :data, :errors, :warnings
+  attr_accessor :name, :options, :shipment, :start, :end
+  def self.default_shipment=(shipment)
+    @default_shipment = shipment
+  end
 
-  def initialize(shipment, options = {}) # rubocop:disable Metrics/MethodLength
+  def self.default_shipment
+    @default_shipment
+  end
+
+  def self.json_create(hash)
+    raise "no default_shipment set" if self.class.default_shipment.nil?
+
+    new self.default_shipment, hash['errors'], hash['warnings'], hash['data'],
+        hash['start'], hash['end']
+  end
+  
+  def to_json(*args)
+    {
+      'json_class' => self.class.name,
+      'data' => { name: @name,
+                  errors: @errors,
+                  warnings: @warnings,
+                  data: @data,
+                  start: @start.to_s,
+                  end: @end.to_s }
+    }.to_json(*args)
+  end
+
+  def initialize(shipment, **args) # rubocop:disable Metrics/MethodLength
     unless shipment.is_a? Shipment
       raise StandardError,
             "shipment class #{shipment.class} for #{self.class}#initialize"
     end
-    raise "nil options passed to #{self.class}#initialize" if options.nil?
-
-    @name = self.class.to_s
     @shipment = shipment
-    @options = options # Hash of command-line arguments
-    # FIXME: change this back to @errors when tests are passing,
-    # maybe restore attr_reader
-    @errs = [] # Fatal conditions, Array of Error
-    @warns = [] # Nonfatal conditions, Array of Error
-    @data = {} # A data structure that is written to status.json for the stage
+    @metadata = metadata
+    @name = args[:name] || self.class.to_s
+    @options = {} # Hash of command-line arguments
+    @errors = args[:errors] || [] # Fatal conditions, Array of Error
+    @warnings = args[:warnings] || [] # Nonfatal conditions, Array of Error
+    @data = args[:data] || {} # Misc data structure including log
+    # Time the stage was last run (may be unneeded)
+    @start = args[:start].nil? ? nil : Time.parse(args[:start])
+    # Time the stage last finished running (may be unneeded)
+    @end = args[:end].nil? ? nil : Time.parse(args[:end])
   end
 
-  def run
-    raise "#{self.class.name}.run() method unimplemented"
+  def run(_agenda)
+    raise "#{self.class.name}#run method unimplemented"
   end
 
   def add_error(err)
     raise "nil err passed to #{self.class}#add_error" if err.nil?
     raise "#{err.class} passed to add_error" unless err.is_a? Error
 
-    @errs << err
+    @errors << err
   end
 
   def add_warning(err)
     raise "nil err passed to #{self.class}#add_warning" if err.nil?
     raise "#{err.class} passed to add_warning" unless err.is_a? Error
 
-    @warns << err
+    @warnings << err
   end
 
-  def errors
-    @errs
-  end
-
-  def warnings
-    @warns
-  end
-
-  # OK to make destructive changes to the shipment
-  # FIXME: rename make_changes_to_barcode?
-  def make_changes?
-    @errs.none? && !@options[:noop]
+  # OK to make destructive changes to the shipment for this barcode?
+  # With nil barcode checks for presence of fatal error.
+  # This should be called like "if make changes? && make_changes?(barcode)"
+  def make_changes?(barcode = nil)
+    @errors.none? { |e| e.barcode == barcode }
   end
 
   # Expected to be run as part of #run,
@@ -64,17 +86,18 @@ class Stage # rubocop:disable Metrics/ClassLength
     cleanup_copy_on_success
     cleanup_delete_on_success
     cleanup_tempdirs
+    write_progress(0, 0) unless @progress.nil?
   end
 
   def cleanup_copy_on_success
     return if @copy_on_success.nil?
 
     while @copy_on_success.any?
-      pair = @copy_on_success.pop
-      if make_changes?
-        FileUtils.cp pair[0], pair[1]
+      copy = @copy_on_success.pop
+      if make_changes? copy[:barcode]
+        FileUtils.cp copy[:source], copy[:destination]
       else
-        FileUtils.rm pair[0]
+        FileUtils.rm copy[:source]
       end
     end
   end
@@ -82,13 +105,16 @@ class Stage # rubocop:disable Metrics/ClassLength
   def cleanup_delete_on_success
     return if @delete_on_success.nil? || !make_changes?
 
-    FileUtils.rm @delete_on_success.pop while @delete_on_success.any?
+    @delete_on_success.each do |del|
+      FileUtils.rm del[:path] if make_changes? del[:barcode]
+    end
+    @delete_on_success = nil
   end
 
   def cleanup_tempdirs
-    return if @tempdirs.nil?
-
-    FileUtils.rm_rf @tempdirs.pop while @tempdirs.any?
+    unless @tempdirs.nil? # ruboccop:disable Style/IfUnlessModifier
+      FileUtils.rm_rf @tempdirs.pop while @tempdirs.any?
+    end
     return unless File.directory? shipment.tmp_directory
 
     FileUtils.rm_rf shipment.tmp_directory
@@ -103,13 +129,14 @@ class Stage # rubocop:disable Metrics/ClassLength
   end
 
   # source is copied to destination on success,
-  # deleted on failure or if noop option flag is set.
-  def copy_on_success(source, destination)
-    (@copy_on_success ||= []) << [source, destination]
+  # deleted on failure.
+  def copy_on_success(source, destination, barcode)
+    (@copy_on_success ||= []) << { source: source, destination: destination,
+                                   barcode: barcode }
   end
 
-  def delete_on_success(path)
-    (@delete_on_success ||= []) << path
+  def delete_on_success(path, barcode)
+    (@delete_on_success ||= []) << { path: path, barcode: barcode }
   end
 
   def barcode_from_path(path)
@@ -143,16 +170,21 @@ class Stage # rubocop:disable Metrics/ClassLength
   # Write a single-line progress bar.
   # The \033[K is to erase the entire line in case a previous action string
   # might not be completely overwritten by a subsequent shorter one.
-  def write_progress(finished, total, action = '')
+  def write_progress(finished, total, action = '') # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     return if @options[:no_progress]
 
-    progress = 10 * finished / total
+    progress = total.zero? ? 10 : 10 * finished / total
     block = '█'.encode('utf-8')
     bar = format '%<bar>-10s', bar: block * progress
-    bar = bar.red if @errs.count.positive?
-    printf("\r\033[K%-16s |%s| (#{finished}/#{total}) #{action}",
-           self.class, bar)
-    @progress = progress
-    puts "\n" if @progress >= 10
+    bar = bar.red if @errors.count.positive?
+    fmt = format("\r\033[K%-16s |%s| (#{finished}/#{total}) #{action}",
+                 self.class, bar)
+    print fmt if @progress.nil? || @progress != fmt
+    if progress >= 10
+      print "\n"
+      @progress = nil
+    else
+      @progress = fmt
+    end
   end
 end

--- a/lib/stage.rb
+++ b/lib/stage.rb
@@ -10,6 +10,7 @@ require 'error'
 class Stage # rubocop:disable Metrics/ClassLength
   attr_reader :data, :errors, :warnings
   attr_accessor :name, :options, :shipment, :start, :end
+
   def self.default_shipment=(shipment)
     @default_shipment = shipment
   end
@@ -19,9 +20,9 @@ class Stage # rubocop:disable Metrics/ClassLength
   end
 
   def self.json_create(hash)
-    raise "no default_shipment set" if self.class.default_shipment.nil?
+    raise 'no default_shipment set' if self.class.default_shipment.nil?
 
-    new self.default_shipment, hash['errors'], hash['warnings'], hash['data'],
+    new default_shipment, hash['errors'], hash['warnings'], hash['data'],
         hash['start'], hash['end']
   end
   
@@ -37,13 +38,12 @@ class Stage # rubocop:disable Metrics/ClassLength
     }.to_json(*args)
   end
 
-  def initialize(shipment, **args) # rubocop:disable Metrics/MethodLength
-    unless shipment.is_a? Shipment
-      raise StandardError,
-            "shipment class #{shipment.class} for #{self.class}#initialize"
+  def initialize(shipment, **args) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+    unless shipment.nil? || shipment.is_a?(Shipment)
+      raise StandardError, "unknown shipment class #{shipment.class}"
     end
+
     @shipment = shipment
-    @metadata = metadata
     @name = args[:name] || self.class.to_s
     @options = {} # Hash of command-line arguments
     @errors = args[:errors] || [] # Fatal conditions, Array of Error

--- a/lib/tiff_validator.rb
+++ b/lib/tiff_validator.rb
@@ -9,16 +9,17 @@ class TIFFValidator < Stage
   BITONAL_RES = '600'
   CONTONE_RES = '400'
 
-  def run # rubocop:disable Metrics/AbcSize
-    image_files.each_with_index do |image_file, i|
-      write_progress(i, image_files.count, image_file.barcode_file)
+  def run(agenda = shipment.barcodes) # rubocop:disable Metrics/AbcSize
+    files = image_files.select { |file| agenda.include? file.barcode }
+    files.each_with_index do |image_file, i|
+      write_progress(i, files.count, image_file.barcode_file)
       fields = extract_tiff_fields run_tiffinfo(image_file)
       err = evaluate fields
       unless err.nil?
         add_error Error.new(err, image_file.barcode, image_file.path)
       end
     end
-    write_progress(image_files.count, image_files.count)
+    write_progress(files.count, files.count)
   end
 
   private

--- a/process.rb
+++ b/process.rb
@@ -59,10 +59,24 @@ rescue JSON::ParserError => e
   exit 1
 end
 
-begin
-  processor.run
-rescue Interrupt
-  puts "\nInterrupted".red
-ensure
-  processor.write_status
+
+ARGV.each do |dir|
+  dir = Pathname.new(dir).cleanpath.to_s
+  unless File.exist?(dir) && File.directory?(dir)
+    puts "Shipment directory #{dir.bold} does not exist, skipping".red
+    next
+  end
+  begin
+    processor = Processor.new(dir, options)
+  rescue JSON::ParserError => e
+    puts "unable to parse #{File.join(dir, status.json)}: #{e}"
+    next
+  end
+  begin
+    processor.run
+  rescue Interrupt
+    puts "\nInterrupted".red
+  ensure
+    processor.write_status
+  end
 end

--- a/process.rb
+++ b/process.rb
@@ -59,9 +59,8 @@ rescue JSON::ParserError => e
   exit 1
 end
 
-
-ARGV.each do |dir|
-  dir = Pathname.new(dir).cleanpath.to_s
+ARGV.each do |arg|
+  dir = Pathname.new(arg).cleanpath.to_s
   unless File.exist?(dir) && File.directory?(dir)
     puts "Shipment directory #{dir.bold} does not exist, skipping".red
     next

--- a/process.sh
+++ b/process.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
-
-BUNDLE_GEMFILE="$(dirname $0)"/Gemfile bundle exec "$(dirname $0)"/process.rb $*
+RBENV_VERSION="2.6.6"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+BUNDLE_GEMFILE="$SCRIPT_DIR"/Gemfile
+RBENV_VERSION=$RBENV_VERSION BUNDLE_GEMFILE=$BUNDLE_GEMFILE bundle exec "$SCRIPT_DIR"/process.rb $*

--- a/query.rb
+++ b/query.rb
@@ -121,7 +121,7 @@ begin
           puts "\nInterrupted".red
         ensure
           processor.write_status
-      end
+        end
       when 'status'
         processor.query
       when 'warnings'

--- a/query.sh
+++ b/query.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
-
-BUNDLE_GEMFILE="$(dirname $0)"/Gemfile bundle exec "$(dirname $0)"/query.rb $*
+RBENV_VERSION="2.6.6"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+BUNDLE_GEMFILE="$SCRIPT_DIR"/Gemfile
+RBENV_VERSION=$RBENV_VERSION BUNDLE_GEMFILE=$BUNDLE_GEMFILE bundle exec "$SCRIPT_DIR"/query.rb $*


### PR DESCRIPTION
Make `RBENV_VERSION` and `GEMFILE_PATH` explicit in the shell commands. There was an issue with the default Ruby on the server being set to 2.5 rather than 2.6, and hence a lot of `bundle install` confusion.