### PR TITLE
Make query.sh and process.sh more bulletproof.

### DIFF
--- a/process.sh
+++ b/process.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
-
-BUNDLE_GEMFILE="$(dirname $0)"/Gemfile bundle exec "$(dirname $0)"/process.rb $*
+RBENV_VERSION="2.6.6"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+BUNDLE_GEMFILE="$SCRIPT_DIR"/Gemfile
+RBENV_VERSION=$RBENV_VERSION BUNDLE_GEMFILE=$BUNDLE_GEMFILE bundle exec "$SCRIPT_DIR"/process.rb $*

--- a/query.sh
+++ b/query.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
-
-BUNDLE_GEMFILE="$(dirname $0)"/Gemfile bundle exec "$(dirname $0)"/query.rb $*
+RBENV_VERSION="2.6.6"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+BUNDLE_GEMFILE="$SCRIPT_DIR"/Gemfile
+RBENV_VERSION=$RBENV_VERSION BUNDLE_GEMFILE=$BUNDLE_GEMFILE bundle exec "$SCRIPT_DIR"/query.rb $*


### PR DESCRIPTION
Make `RBENV_VERSION` and `BUNDLE_GEMFILE` explicit in and use full path with shell scripts. The default Ruby on our server is 2.5 rather than 2.6, hence a lot of unnecessary `bundle install` confusion.