### PR TITLE
Addresses #45 PaginationCheck creates Error.barcode with path

### DIFF
--- a/test/pagination_check_test.rb
+++ b/test/pagination_check_test.rb
@@ -27,11 +27,13 @@ class PaginationCheckTest < Minitest::Test
     assert(stage.warnings.none?, 'no warnings')
   end
 
-  def test_missing
+  def test_missing # rubocop:disable Metrics/AbcSize
     shipment = TestShipment.new(test_name, 'BC T bitonal 1-2 T bitonal 4-5')
     stage = PaginationCheck.new(shipment, @options)
     stage.run
     assert(stage.errors.count == 1, 'one missing page error')
+    assert_equal(stage.errors[0].barcode, shipment.barcodes[0],
+                 'error barcode is shipment barcode')
     assert_match(/missing/, stage.errors[0].description,
                  'error contains "missing"')
   end


### PR DESCRIPTION
Pretty straightforward fix using `shipment.barcodes` instead of `barcode_directories` so we can just hand the barcode off to any error messages that may be needed.

Shifted from `@bar.step!` to `@bar.next!` as kind of an afterthought to further simplify the code.