### PR TITLE
Addresses #67 query.rb COMMAND_SUMMARY error

### DIFF
--- a/query.rb
+++ b/query.rb
@@ -87,7 +87,7 @@ begin
       when 'errors'
         tool.errors_cmd(*args)
       when 'help', '?'
-        puts command_summary
+        puts COMMAND_SUMMARY
       when 'fixity'
         tool.fixity_cmd
       when 'quit', 'exit'


### PR DESCRIPTION
Using uppercase because it's a constant. RuboCop doesn't seem to mind either way.