### PR TITLE
Addresses #73 More ingelligent TIFFValidator errors

### DIFF
--- a/test/tiff_validator_test.rb
+++ b/test/tiff_validator_test.rb
@@ -89,4 +89,16 @@ class TIFFValidatorTest < Minitest::Test
     assert(stage.errors.any? { |e| /100x100\scontone/i.match? e.to_s },
            '100x100 contone TIFF rejected')
   end
+
+  def test_garbage_tiff_fails
+    spec = 'BC T contone 1'
+    shipment = TestShipment.new(test_name, spec)
+    stage = TIFFValidator.new(shipment, config: @config)
+    tiff = File.join(shipment.directory, shipment.barcodes[0], '00000001.tif')
+    `/bin/echo -n 'test' > #{tiff}`
+    stage.run!
+    assert(stage.errors.count == 1, 'garbage TIFF generates one error')
+    assert(stage.errors.any? { |e| /cannot read tiff header/i.match? e.to_s },
+           'garbage TIFF rejected with message about TIFF header')
+  end
 end


### PR DESCRIPTION
Fixes an issue where tiffinfo exit status is checked first and bails out before the fun stuff from STDERR can be collected. Here we check STDERR first and only report an exit status error if there was no other error text.

Additionally, Error objects in this stage can be created with only a TIFF filename, no need to clutter errors with the full path. 