### PR TITLE
Addresses #72 Stale path in serialized Shipment

### DIFF
--- a/lib/processor.rb
+++ b/lib/processor.rb
@@ -19,8 +19,14 @@ class Processor # rubocop:disable Metrics/ClassLength
   attr_reader :dir, :config, :shipment
 
   # Can take either a directory path or a Shipment
-  def initialize(dir, options = {})
-    @shipment = dir.is_a?(Shipment) ? dir : Shipment.new(dir)
+  def initialize(dir, options = {}) # rubocop:disable Metrics/MethodLength
+    if dir.is_a?(Shipment)
+      @shipment = dir
+      @dir = @shipment.directory
+    else
+      @dir = dir
+      @shipment = Shipment.new(dir)
+    end
     @config = Config.new(options)
     config[:stages].each do |s|
       require s[:file]
@@ -217,6 +223,7 @@ class Processor # rubocop:disable Metrics/ClassLength
       end
 
       @shipment = status[:shipment]
+      @shipment.directory = @dir
       @stages = status[:stages]
       @stages.each do |s|
         s.shipment = @shipment

--- a/lib/shipment.rb
+++ b/lib/shipment.rb
@@ -41,6 +41,16 @@ class Shipment # rubocop:disable Metrics/ClassLength
     @dir
   end
 
+  # Should only be necessary when loading from a status.json that has moved.
+  # Assign new value and blow away any and all memoized paths.
+  def directory=(dir)
+    return if @dir == dir
+
+    @dir = dir
+    @source_directory = nil
+    @tmp_directory = nil
+  end
+
   def source_directory
     @source_directory ||= File.join @dir, 'source'
   end

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -89,6 +89,21 @@ class ProcessorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
     assert_kind_of Error, errs[0], 'Error class reconstituted from status.json'
   end
 
+  # Don't pass TestShipment to anything we want to serialize --
+  # the initializer isn't JSON-aware
+  def test_move_status_file # rubocop:disable Metrics/AbcSize
+    shipment = TestShipment.new(test_name, 'BC')
+    processor = Processor.new(shipment.directory)
+    processor.write_status_file
+    shipment_copy_dir = File.join(TestShipment::PATH, test_name + '_COPY')
+    FileUtils.copy_entry(shipment.directory, shipment_copy_dir)
+    FileUtils.rm_r(shipment.directory, force: true)
+    processor = Processor.new(shipment_copy_dir)
+    assert_equal 1, processor.shipment.barcodes.count,
+                 'relocated shipment can access its barcodes'
+    FileUtils.rm_r(shipment_copy_dir, force: true)
+  end
+
   def test_restore_from_source_directory # rubocop:disable Metrics/MethodLength
     shipment = TestShipment.new(test_name, 'BC T contone 1')
     processor = Processor.new(shipment, {})


### PR DESCRIPTION
The full path shouldn't even be in the serialized `Shipment` object, arguably. But for now this allows `Processor` to set the location based on what came in from the command line, overriding the `status.json` value. This was encountered in actual testing, not surprising given the DCU penchant for moving stuff around.