### PR TITLE
Addresses #80 Kakadu demo binaries for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,14 @@ RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
 
 RUN gem install bundler
 
+WORKDIR /tmp
+RUN wget http://kakadusoftware.com/wp-content/uploads/KDU805_Demo_Apps_for_Linux-x86-64_200602.zip
+RUN unzip -j -d kakadu KDU805_Demo_Apps_for_Linux-x86-64_200602.zip
+RUN mv /tmp/kakadu/*.so /usr/local/lib
+RUN mv /tmp/kakadu/kdu* /usr/local/bin
+RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/kakadu.conf
+RUN ldconfig
+
 ENV APP_PATH /usr/src/app
 RUN mkdir -p $APP_PATH
 WORKDIR $APP_PATH

--- a/lib/stage/compressor.rb
+++ b/lib/stage/compressor.rb
@@ -179,8 +179,6 @@ class Compressor < Stage # rubocop:disable Metrics/ClassLength
           " 'Cuse_eph=#{JP2_USE_EPH}'" \
           " Cmodes=#{JP2_MODES}" \
           " -no_weights -slope '#{JP2_SLOPE}'"
-    # For testing under Docker, fall back to ImageMagick instead of Kakadu
-    cmd = "convert #{source} #{destination}" if ENV['KAKADONT']
     _stdout_str, stderr_str, code = Open3.capture3(cmd)
     unless code.exitstatus.zero?
       raise CompressorError.new('Could not convert to JPEG 2000',

--- a/lib/stage/dlxs_compressor.rb
+++ b/lib/stage/dlxs_compressor.rb
@@ -49,8 +49,6 @@ class DLXSCompressor < Stage
   # Expand existing jp2 into tif in temp directory
   def expand_jp2(src, dest)
     cmd = "kdu_expand -i '#{src}' -o '#{dest}'"
-    # For testing under Docker, fall back to ImageMagick instead of Kakadu
-    cmd = "convert #{src} #{dest}" if ENV['KAKADONT']
     _stdout_str, stderr_str, code = Open3.capture3(cmd)
     unless code.exitstatus.zero?
       raise DLXSCompressorError.new('Could not expand JPEG 2000',

--- a/test/compressor_test.rb
+++ b/test/compressor_test.rb
@@ -7,8 +7,6 @@ require 'fixtures'
 
 class CompressorTest < Minitest::Test
   def setup
-    # For testing under Docker, fall back to ImageMagick instead of Kakadu
-    ENV['KAKADONT'] = '1'
     @config = Config.new({ no_progress: true })
   end
 

--- a/test/dlxs_compressor_test.rb
+++ b/test/dlxs_compressor_test.rb
@@ -7,8 +7,6 @@ require 'fixtures'
 
 class DLXSCompressorTest < Minitest::Test
   def setup
-    # For testing under Docker, fall back to ImageMagick instead of Kakadu
-    ENV['KAKADONT'] = '1'
     @config = Config.new({ no_progress: true })
   end
 

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -8,8 +8,6 @@ require 'fixtures'
 class ProcessorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
   def setup
     @options = { config_dir: File.join(TEST_ROOT, 'config') }
-    # For testing under Docker, fall back to ImageMagick instead of Kakadu
-    ENV['KAKADONT'] = '1'
   end
 
   def teardown

--- a/test/query_tool_test.rb
+++ b/test/query_tool_test.rb
@@ -9,8 +9,6 @@ class QueryToolTestTest < Minitest::Test # rubocop:disable Metrics/ClassLength
   def setup
     @options = { config_dir: File.join(TEST_ROOT, 'config'),
                  no_progress: true }
-    # For testing under Docker, fall back to ImageMagick instead of Kakadu
-    ENV['KAKADONT'] = '1'
   end
 
   def test_new


### PR DESCRIPTION
Get rid of yucky `KAKADONT` environment variable hack used in tests by using Kakadu demo Linux binaries under Docker.