### PR TITLE
Addresses #85 -R flag vs finalized shipment

### DIFF
--- a/lib/processor.rb
+++ b/lib/processor.rb
@@ -35,7 +35,9 @@ class Processor # rubocop:disable Metrics/ClassLength
     stages
   end
 
-  def run
+  def run # rubocop:disable Metrics/MethodLength
+    raise FinalizedShipmentError if shipment.finalized?
+
     if config[:restart_all]
       restore_from_source_directory
     else
@@ -149,6 +151,10 @@ class Processor # rubocop:disable Metrics/ClassLength
     @status_file ||= File.join(@shipment.directory, 'status.json')
   end
 
+  def status_file?
+    File.exist? status_file
+  end
+
   def write_status_file
     puts "Writing status file #{status_file}" if config[:verbose]
     File.open(status_file, 'w') do |f|
@@ -206,7 +212,7 @@ class Processor # rubocop:disable Metrics/ClassLength
     end
 
     if config[:restart_all]
-      raise FinalizedShipmentError if status[:shipment].metadata[:finalized]
+      raise FinalizedShipmentError if status[:shipment].finalized?
 
     else
       @shipment = status[:shipment]

--- a/process.rb
+++ b/process.rb
@@ -77,14 +77,16 @@ ARGV.each do |arg| # rubocop:disable Metrics/BlockLength
   begin
     puts "Processing #{dir}...".blue
     processor.run
+    processor.finalize
   rescue Interrupt
     puts "\nInterrupted".red
+    next
   rescue FinalizedShipmentError
     puts 'Shipment has been finalized, image masters unavailable'.red
-  ensure
-    processor.finalize
-    processor.write_status_file
-    tool = QueryTool.new processor
-    tool.status_cmd
+    next
   end
+  puts "FIXME: we'd like to bypass this if we get FinalizedShipmentError"
+  processor.write_status_file
+  tool = QueryTool.new processor
+  tool.status_cmd
 end

--- a/shipments.rb
+++ b/shipments.rb
@@ -58,16 +58,15 @@ ARGV.each do |arg|
     statuses[arg] = 'Not a directory'.red
     next
   end
-  shipment = Shipment.new(dir)
-  if shipment.status_file?
-    begin
-      processor = Processor.new(shipment, options)
-      statuses[arg] = processor.errors.none? ? 'OK'.green : 'ERRORS'.red
-    rescue JSON::ParserError => e
-      statuses[arg] = "Can't parse #{shipment.status_file}: #{e}".red
+  begin
+    processor = Processor.new(dir, options)
+    unless processor.status_file?
+      statuses[arg] = 'Not a shipment'.red
+      next
     end
-  else
-    statuses[arg] = 'Not a shipment'.red
+    statuses[arg] = processor.errors.none? ? 'OK'.green : 'ERRORS'.red
+  rescue JSON::ParserError => e
+    statuses[arg] = "Can't parse #{shipment.status_file}: #{e}".red
   end
 end
 


### PR DESCRIPTION
This is a fix for the follow-up issue with running against a finalized shipment without the -R flag. Also there is a bug fix for the shipments.rb script which was calling Shipment.status_file? which got moved to Processor.status_file?