### PR TITLE
Addresses 95 Mostly-white DLXS TIFF derivatives

### DIFF
--- a/lib/stage.rb
+++ b/lib/stage.rb
@@ -144,7 +144,7 @@ class Stage # rubocop:disable Metrics/ClassLength
   def make_changes?(barcode = nil)
     return @errors.none? if barcode.nil?
 
-    @errors.none? { |err| e.barcode == barcode || err.barcode.nil? }
+    @errors.none? { |err| err.barcode == barcode || err.barcode.nil? }
   end
 
   # True if the stage has been run and all possible errors have
@@ -191,11 +191,13 @@ class Stage # rubocop:disable Metrics/ClassLength
     FileUtils.rm_rf shipment.tmp_directory
   end
 
-  def create_tempdir
+  # Prefix is useful when debugging image processing pipelines.
+  def create_tempdir(prefix = '')
     unless File.directory? shipment.tmp_directory
       Dir.mkdir shipment.tmp_directory
     end
-    (@tempdirs ||= []) << Dir.mktmpdir(self.class.to_s, shipment.tmp_directory)
+    prefix = self.class.to_s + prefix
+    (@tempdirs ||= []) << Dir.mktmpdir(prefix, shipment.tmp_directory)
     @tempdirs[-1]
   end
 

--- a/lib/stage/dlxs_compressor.rb
+++ b/lib/stage/dlxs_compressor.rb
@@ -32,10 +32,11 @@ class DLXSCompressor < Stage # rubocop:disable Metrics/ClassLength
   private
 
   def handle_conversion(image_file) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-    tmpdir = create_tempdir
+    basename = File.basename(image_file.path, '.*')
+    tmpdir = create_tempdir basename
     source = File.join(tmpdir, 'source.tif')
     bitonal = File.join(tmpdir, 'bitonal.tif')
-    final_image_name = File.basename(image_file.path, '.*') + '.tif'
+    final_image_name = basename + '.tif'
     final_image = File.join(File.dirname(image_file.path), final_image_name)
     expand_jp2 image_file.path, source
     tiff_to_pgm tmpdir
@@ -53,9 +54,6 @@ class DLXSCompressor < Stage # rubocop:disable Metrics/ClassLength
     cmd = <<~CMD.gsub("\n", ' ')
       exiftool -tagsFromFile #{source}
       '-IFD0:DocumentName=#{source_image}'
-      '-IFD0:ImageWidth<XMP-tiff:ImageWidth'
-      '-IFD0:ImageHeight<XMP-tiff:ImageHeight'
-      '-IFD0:BitsPerSample<XMP-tiff:BitsPerSample'
       '-IFD0:Orientation<XMP-tiff:Orientation'
       '-IFD0:ResolutionUnit<XMP-tiff:ResolutionUnit'
       '-IFD0:Artist<XMP-tiff:Artist'
@@ -63,6 +61,7 @@ class DLXSCompressor < Stage # rubocop:disable Metrics/ClassLength
       '-IFD0:Model<XMP-tiff:Model'
       '-IFD0:Software<XMP-tiff:Software'
       '-IFD0:ModifyDate<XMP-tiff:DateTime'
+      '-IFD0:ImageDescription=extracted from JP2'
        -overwrite_original #{destination}
     CMD
     _stdout_str, stderr_str, code = Open3.capture3(cmd)


### PR DESCRIPTION
Removes `DLXSCompressor` `exiftool` parameters that clobber derivative TIFFs by setting incorrect width, height, and bps rather than leaving them intact.

Also fixes a missing one-character variable in `lib/stage.rb`, don't know how that evaded the test suite previously.