### PR TITLE
Addresses #71 Profile time spent in various parts of the system

### DIFF
--- a/lib/command.rb
+++ b/lib/command.rb
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'open3'
+
+# Wrapper for Open3 invocation of external binaries
+class Command
+  attr_reader :status
+
+  def initialize(cmd)
+    @cmd = cmd
+    @status = {}
+  end
+
+  def run(raise_error = true)
+    @start = Time.now
+    stdout_str, stderr_str, code = Open3.capture3(@cmd)
+    if !code.success? && raise_error
+      raise "'#{@cmd}' returned #{code.exitstatus}: #{stderr_str}"
+    end
+
+    @end = Time.now
+    @status = { stdout: stdout_str,
+                stderr: stderr_str,
+                code: code,
+                time: Time.now - @start }
+  end
+end

--- a/lib/jhove.rb
+++ b/lib/jhove.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require 'open3'
+require 'command'
 require 'error'
 require 'symbolize'
 
@@ -30,11 +30,8 @@ class JHOVE # rubocop:disable Metrics/ClassLength
   # This is for Postflight.
   def run
     cmd = feed_validate_script
-    @raw_output, stderr_str, code = Open3.capture3(cmd)
-    unless code.success?
-      raise "'#{cmd}' returned #{code.exitstatus}: #{stderr_str}"
-    end
-
+    status = Command.new(cmd).run
+    @raw_output = status[:stdout]
     process_feed_validate_output
   end
 

--- a/lib/processor.rb
+++ b/lib/processor.rb
@@ -43,7 +43,7 @@ class Processor # rubocop:disable Metrics/ClassLength
     else
       restore_from_source_directory changed_barcodes
     end
-    # Keep open3 quiet when processing is interrupted with Ctrl-C.
+    # Keep Open3 quiet when processing is interrupted with Ctrl-C.
     save_report_on_exception = Thread.report_on_exception
     Thread.report_on_exception = false
     run_stages
@@ -179,18 +179,16 @@ class Processor # rubocop:disable Metrics/ClassLength
 
     stage.reinitialize!
     print_progress "Running stage #{stage.name} with #{agenda}"
-    interrupt = false
     begin
       stage.run! stage_agenda
     rescue Interrupt
       puts "\nInterrupted".red
       stage.add_error Error.new('Interruped')
-      interrupt = true
     rescue StandardError => e
       stage.add_error Error.new("#{e.inspect} #{e.backtrace}")
       puts "#{e.inspect} #{e.backtrace}"
     ensure
-      stage.cleanup interrupt
+      stage.cleanup
       agenda.update stage
     end
   end

--- a/lib/stage/postflight.rb
+++ b/lib/stage/postflight.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require 'digest'
-require 'open3'
 require 'set'
 
 require 'jhove'

--- a/lib/stage/tagger.rb
+++ b/lib/stage/tagger.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require 'open3'
+require 'command'
 require 'stage'
 require 'tag_data'
 
@@ -97,12 +97,12 @@ class Tagger < Stage
 
   def run_tiffset(image_file, tag, value) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     cmd = "tiffset -s #{tag} '#{value}' #{image_file.path}"
-    _stdout_str, stderr_str, code = Open3.capture3(cmd)
-    unless code.exitstatus.zero?
-      add_error Error.new("'#{cmd}': exited with status #{code}",
+    status = Command.new(cmd).run(false)
+    unless status[:code].exitstatus.zero?
+      add_error Error.new("'#{cmd}': exited with status #{status[:code]}",
                           image_file.barcode, image_file.path)
     end
-    stderr_str.chomp.split("\n").each do |err|
+    status[:stderr].chomp.split("\n").each do |err|
       if /tag\signored/.match? err
         add_warning Error.new("#{cmd}: #{err}", image_file.barcode,
                               image_file.path)

--- a/test/command_test.rb
+++ b/test/command_test.rb
@@ -1,0 +1,32 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'command'
+
+class CommandTest < Minitest::Test
+  def test_new
+    config = Command.new('ls')
+    refute_nil config, 'Command successfully created'
+  end
+
+  def test_run
+    status = Command.new('ls').run
+    refute_nil status, 'Command #run returns non-nil status'
+    assert_instance_of String, status[:stdout], 'Command stdout is a String'
+    assert_instance_of String, status[:stderr], 'Command stderr is a String'
+    refute_nil status[:code], 'Command status has non-nil code'
+    assert_instance_of Float, status[:time], 'Command time is a Float'
+  end
+
+  def test_raise
+    assert_raises(StandardError, '#run raises errors by default') do
+      Command.new('ls -0').run
+    end
+  end
+
+  def test_noraise
+    status = Command.new('ls -0').run(false)
+    refute_nil status, 'Command #run returns non-nil status instead of raising'
+  end
+end

--- a/test/compressor_test.rb
+++ b/test/compressor_test.rb
@@ -172,12 +172,3 @@ class CompressorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
 
   invoke_gen
 end
-
-class CompressorErrorTest < MiniTest::Test
-  def test_new
-    err = CompressorError.new('message', 'command', '(detail)')
-    refute_nil err, 'CompressorError successfully created'
-    assert_kind_of StandardError, err, 'error is a kind of StandardError'
-    assert_instance_of CompressorError, err, 'error is CompressorError'
-  end
-end

--- a/test/dlxs_compressor_test.rb
+++ b/test/dlxs_compressor_test.rb
@@ -51,12 +51,3 @@ class DLXSCompressorTest < Minitest::Test
 
   invoke_gen
 end
-
-class DLXSCompressorErrorTest < MiniTest::Test
-  def test_new
-    err = DLXSCompressorError.new('message', 'command', '(detail)')
-    refute_nil err, 'DLXSCompressorError successfully created'
-    assert_kind_of StandardError, err, 'error is a kind of StandardError'
-    assert_instance_of DLXSCompressorError, err, 'error is DLXSCompressorError'
-  end
-end


### PR DESCRIPTION
- `Stage#log` takes a time parameter.
- `Command` class handles running external binaries and collects timing info.
- Query tool "status" command rewrite to display timing.
- `Stage` JSON serialization preserves fractional seconds.