### PR TITLE
Addresses #107 Replace 'barcode' with 'object id'/'objid'

### DIFF
--- a/lib/agenda.rb
+++ b/lib/agenda.rb
@@ -23,14 +23,14 @@ class Agenda
       if source_stage.fatal_error?
         agenda[stage.name.to_sym] = []
       else
-        agenda[stage.name.to_sym].delete_if do |barcode|
-          source_stage.error_barcodes.include? barcode
+        agenda[stage.name.to_sym].delete_if do |objid|
+          source_stage.error_objids.include? objid
         end
       end
     end
   end
 
-  # Stage name -> Array of barcodes that have had no errors in the current run
+  # Stage name -> Array of objids that have had no errors in the current run
   def for_stage(stage)
     agenda[stage.name.to_sym] || []
   end
@@ -41,7 +41,7 @@ class Agenda
 
   private
 
-  # Called once to create to-do list of barcodes for each stage.
+  # Called once to create to-do list of objids for each stage.
   # Initialized with any changes to fixity that have occurred since last run.
   def agenda
     return @agenda unless @agenda.nil?
@@ -49,19 +49,19 @@ class Agenda
     @agenda = {}
     todo = fixity_changes
     @stages.each do |stage|
-      todo.merge @shipment.barcodes unless stage.complete?
+      todo.merge @shipment.objids unless stage.complete?
       @agenda[stage.name.to_sym] = todo.to_a.sort
     end
     @agenda
   end
 
-  # Set of barcodes that have had fixity {added, removed, changed} changes
+  # Set of objids that have had fixity {added, removed, changed} changes
   def fixity_changes
     changes = Set.new
     fixity = @shipment.fixity_check
-    changes.merge fixity[:added].collect(&:barcode).compact
-    changes.merge fixity[:removed].collect(&:barcode).compact
-    changes.merge fixity[:changed].collect(&:barcode).compact
+    changes.merge fixity[:added].collect(&:objid).compact
+    changes.merge fixity[:removed].collect(&:objid).compact
+    changes.merge fixity[:changed].collect(&:objid).compact
     changes
   end
 end

--- a/lib/error.rb
+++ b/lib/error.rb
@@ -6,42 +6,43 @@ require 'json'
 # Processing error class
 # For readability in error messages and elsewhere,
 # wherever possible @path should be relative.
-# In particular when a barcode is included, @path should just be a filename.
+# In particular when an objid is included, @path should just be a filename.
 class Error
   include Comparable
-  attr_reader :description, :barcode, :path
+  attr_reader :description, :objid, :path
 
   def self.json_create(hash)
-    new hash['data']['description'], hash['data']['barcode'],
+    new hash['data']['description'],
+        hash['data']['barcode'] || hash['data']['objid'],
         hash['data']['path']
   end
 
-  def initialize(description, barcode = nil, path = nil)
+  def initialize(description, objid = nil, path = nil)
     raise 'nil description passed to Error#initialize' if description.nil?
 
     @description = description
-    @barcode = barcode
+    @objid = objid
     @path = path
   end
 
   def <=>(other)
     return nil unless other.is_a?(self.class)
 
-    [@barcode || '', @path || '', @description] <=>
-      [other.barcode || '', other.path || '', other.description]
+    [@objid || '', @path || '', @description] <=>
+      [other.objid || '', other.path || '', other.description]
   end
 
   def to_s
-    format '%<description>s%<barcode>s%<path>s',
+    format '%<description>s%<objid>s%<path>s',
            description: @description,
-           barcode: (@barcode.nil? ? '' : " #{@barcode}"),
+           objid: (@objid.nil? ? '' : " #{@objid}"),
            path: (@path.nil? ? '' : " #{@path}")
   end
 
   def to_json(*args)
     {
       'json_class' => self.class.name,
-      'data' => { description: @description, barcode: @barcode, path: @path }
+      'data' => { description: @description, objid: @objid, path: @path }
     }.to_json(*args)
   end
 end

--- a/lib/jhove.rb
+++ b/lib/jhove.rb
@@ -13,11 +13,11 @@ class JHOVE # rubocop:disable Metrics/ClassLength
                      remediable seq stage].freeze
 
   # Convert error Hash to Postflight Error object
-  def self.error_object(err, barcode = nil)
+  def self.error_object(err, objid = nil)
     fields = err.reject { |k, _v| JHOVE::UNUSED_FIELDS.include? k }
     desc = "#{err[:description]}: " +
            fields.map { |k, v| "#{k}: #{v}" }.join(', ')
-    Error.new desc, barcode, err[:file]
+    Error.new desc, objid, err[:file]
   end
 
   def initialize(directory, config)
@@ -56,7 +56,6 @@ class JHOVE # rubocop:disable Metrics/ClassLength
 
   def feed_validate_script
     components = ['perl', @config[:feed_validate_script], 'google mdp', @dir]
-    components << @barcode unless @barcode.nil?
     components.join ' '
   end
 

--- a/lib/processor.rb
+++ b/lib/processor.rb
@@ -41,7 +41,7 @@ class Processor # rubocop:disable Metrics/ClassLength
     if config[:restart_all]
       restore_from_source_directory
     else
-      restore_from_source_directory changed_barcodes
+      restore_from_source_directory changed_objids
     end
     # Keep Open3 quiet when processing is interrupted with Ctrl-C.
     save_report_on_exception = Thread.report_on_exception
@@ -63,15 +63,15 @@ class Processor # rubocop:disable Metrics/ClassLength
   end
 
   # As with Shipment#restore_from_source_directory, takes nil to replace all,
-  # barcode Array otherwise.
-  def restore_from_source_directory(barcodes = nil)
-    return if barcodes == []
+  # objid Array otherwise.
+  def restore_from_source_directory(objids = nil)
+    return if objids == []
     return unless File.directory? shipment.source_directory
 
     bar = ProgressBar.new('(Restore)')
-    bar.steps = @shipment.source_barcode_directories.count
-    @shipment.restore_from_source_directory(barcodes) do |barcode|
-      bar.next! "copying from source/#{barcode}"
+    bar.steps = @shipment.source_objid_directories.count
+    @shipment.restore_from_source_directory(objids) do |objid|
+      bar.next! "copying from source/#{objid}"
     end
     bar.done!
   end
@@ -93,53 +93,53 @@ class Processor # rubocop:disable Metrics/ClassLength
     @agenda ||= Agenda.new(@shipment, @stages)
   end
 
-  # Map of stage name -> barcode + nil -> [Errors]
+  # Map of stage name -> objid + nil -> [Errors]
   # Does not include stages with no errors
   def errors
     errs = {}
     stages.each do |stage|
-      stage_errs = stage.errors_by_barcode
+      stage_errs = stage.errors_by_objid
       errs[stage.name] = stage_errs unless stage_errs.empty?
     end
     errs
   end
 
-  # Map of stage name -> barcode + nil -> [Errors]
+  # Map of stage name -> objid + nil -> [Errors]
   # Does not include stages with no errors
   def warnings
     warnings = {}
     stages.each do |stage|
-      stage_warnings = stage.warnings_by_barcode
+      stage_warnings = stage.warnings_by_objid
       warnings[stage.name] = stage_warnings unless stage_warnings.empty?
     end
     warnings
   end
 
-  # Map of barcode + nil -> stage name -> [Errors]
-  # Does not include barcodes with no errors
-  def errors_by_barcode_by_stage
+  # Map of objid + nil -> stage name -> [Errors]
+  # Does not include objids with no errors
+  def errors_by_objid_by_stage
     errs = {}
-    (@shipment.barcodes + [nil]).each do |barcode|
+    (@shipment.objids + [nil]).each do |objid|
       stages.each do |stage|
-        stage_errs = stage.errors.select { |err| err.barcode == barcode }
+        stage_errs = stage.errors.select { |err| err.objid == objid }
         next if stage_errs.none?
 
-        (errs[barcode] ||= {})[stage.name] = stage_errs
+        (errs[objid] ||= {})[stage.name] = stage_errs
       end
     end
     errs
   end
 
-  # Map of barcode + nil -> stage name -> [Errors]
-  # Does not include barcodes with no warnings
-  def warnings_by_barcode_by_stage
+  # Map of objid + nil -> stage name -> [Errors]
+  # Does not include objids with no warnings
+  def warnings_by_objid_by_stage
     warnings = {}
-    (@shipment.barcodes + [nil]).each do |barcode|
+    (@shipment.objids + [nil]).each do |objid|
       stages.each do |stage|
-        stage_warnings = stage.warnings.select { |err| err.barcode == barcode }
+        stage_warnings = stage.warnings.select { |err| err.objid == objid }
         next if stage_warnings.none?
 
-        (warnings[barcode] ||= {})[stage.name] = stage_warnings
+        (warnings[objid] ||= {})[stage.name] = stage_warnings
       end
     end
     warnings
@@ -233,11 +233,11 @@ class Processor # rubocop:disable Metrics/ClassLength
     end
   end
 
-  def changed_barcodes
+  def changed_objids
     fixity = shipment.fixity_check
-    [fixity[:added].collect(&:barcode),
-     fixity[:removed].collect(&:barcode),
-     fixity[:changed].collect(&:barcode)].flatten.uniq
+    [fixity[:added].collect(&:objid),
+     fixity[:removed].collect(&:objid),
+     fixity[:changed].collect(&:objid)].flatten.uniq
   end
 
   # Verbose printing of progress information

--- a/lib/stage/dlxs_compressor.rb
+++ b/lib/stage/dlxs_compressor.rb
@@ -9,14 +9,14 @@ class DLXSCompressor < Stage # rubocop:disable Metrics/ClassLength
   def run(agenda) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     return unless agenda.any?
 
-    files = image_files('jp2').select { |file| agenda.include? file.barcode }
+    files = image_files('jp2').select { |file| agenda.include? file.objid }
     @bar.steps = files.count
     files.each_with_index do |image_file, i|
-      @bar.step! i, image_file.barcode_file
+      @bar.step! i, image_file.objid_file
       begin
         handle_conversion image_file
       rescue StandardError => e
-        add_error Error.new(e.message, image_file.barcode, image_file.path)
+        add_error Error.new(e.message, image_file.objid, image_file.path)
       end
     end
   end
@@ -33,12 +33,12 @@ class DLXSCompressor < Stage # rubocop:disable Metrics/ClassLength
     expand_jp2 image_file.path, source
     tiff_to_pgm tmpdir
     pgm_to_bitonal tmpdir
-    source_image = File.join(shipment.barcode_to_path(image_file.barcode),
+    source_image = File.join(shipment.objid_to_path(image_file.objid),
                              final_image_name)
     copy_metadata image_file.path, bitonal, source_image
-    copy_on_success bitonal, final_image, image_file.barcode
+    copy_on_success bitonal, final_image, image_file.objid
     copy_on_success image_file.path, jp2_name(image_file.path),
-                    image_file.barcode
+                    image_file.objid
     delete_on_success image_file.path
   end
 

--- a/lib/stage/pagination_check.rb
+++ b/lib/stage/pagination_check.rb
@@ -8,25 +8,25 @@ class PaginationCheck < Stage
   IMAGE_FILE_RE = /^([0-9]{8})\.(?:tif|jp2)$/.freeze
 
   def run(agenda)
-    agenda.each do |barcode|
-      @bar.next! barcode
-      find_barcode_errors barcode
+    agenda.each do |objid|
+      @bar.next! objid
+      find_objid_errors objid
     end
   end
 
   private
 
-  def find_barcode_errors(barcode)
-    dir = @shipment.barcode_directory barcode
+  def find_objid_errors(objid)
+    dir = @shipment.objid_directory objid
     pages = pages_in_dir(dir)
     missing = missing_pages(pages)
     if missing.count.positive?
-      add_error Error.new("missing pages {#{missing.join(', ')}}", barcode)
+      add_error Error.new("missing pages {#{missing.join(', ')}}", objid)
     end
     duplicate = duplicate_pages(pages)
     return unless duplicate.count.positive?
 
-    add_error Error.new("duplicate pages {#{duplicate.join(', ')}}", barcode)
+    add_error Error.new("duplicate pages {#{duplicate.join(', ')}}", objid)
   end
 
   def pages_in_dir(dir)

--- a/lib/stage/postflight.rb
+++ b/lib/stage/postflight.rb
@@ -11,12 +11,12 @@ require 'stage'
 class Postflight < Stage
   def run(agenda)
     @bar.steps = steps agenda
-    agenda.each do |barcode|
-      @bar.next! "validate #{barcode}"
-      run_jhove barcode
+    agenda.each do |objid|
+      @bar.next! "validate #{objid}"
+      run_jhove objid
     end
-    @bar.next! 'barcode check'
-    check_barcode_lists
+    @bar.next! 'objid check'
+    check_objid_lists
     @bar.next! 'verify checksums'
     verify_source_checksums
   end
@@ -29,38 +29,38 @@ class Postflight < Stage
       shipment.checksums.keys.count
   end
 
-  def check_barcode_lists # rubocop:disable Metrics/AbcSize
+  def check_objid_lists # rubocop:disable Metrics/AbcSize
     s1 = Set.new shipment.metadata[:initial_barcodes]
-    s2 = Set.new shipment.barcodes
+    s2 = Set.new shipment.objids
     if (s1 - s2).any?
-      add_error Error.new("barcodes removed: #{(s1 - s2).to_a.join(', ')}")
+      add_error Error.new("objids removed: #{(s1 - s2).to_a.join(', ')}")
     end
     return unless (s2 - s1).any?
 
-    add_error Error.new("barcodes added: #{(s2 - s1).to_a.join(', ')}")
+    add_error Error.new("objids added: #{(s2 - s1).to_a.join(', ')}")
   end
 
   def verify_source_checksums # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     fixity = shipment.fixity_check do |image_file|
-      @bar.next! image_file.barcode_file
+      @bar.next! image_file.objid_file
     end
     fixity[:added].each do |image_file|
-      add_error Error.new('SHA missing', image_file.barcode, image_file.file)
+      add_error Error.new('SHA missing', image_file.objid, image_file.file)
     end
     fixity[:removed].each do |image_file|
-      add_error Error.new('file missing', image_file.barcode, image_file.file)
+      add_error Error.new('file missing', image_file.objid, image_file.file)
     end
     fixity[:changed].each do |image_file|
-      add_error Error.new('SHA modified', image_file.barcode, image_file.file)
+      add_error Error.new('SHA modified', image_file.objid, image_file.file)
     end
   end
 
-  def run_jhove(barcode)
-    jhove = JHOVE.new(shipment.barcode_directory(barcode), config)
+  def run_jhove(objid)
+    jhove = JHOVE.new(shipment.objid_directory(objid), config)
     begin
       jhove.run
     rescue StandardError => e
-      add_error Error.new(e.message, barcode)
+      add_error Error.new(e.message, objid)
     end
     jhove.errors.each do |err|
       add_error JHOVE.error_object(err)

--- a/lib/stage/tiff_validator.rb
+++ b/lib/stage/tiff_validator.rb
@@ -13,10 +13,10 @@ class TIFFValidator < Stage
   def run(agenda)
     return unless agenda.any?
 
-    files = image_files.select { |file| agenda.include? file.barcode }
+    files = image_files.select { |file| agenda.include? file.objid }
     @bar.steps = files.count
     files.each do |image_file|
-      @bar.next! image_file.barcode_file
+      @bar.next! image_file.objid_file
       tiffinfo = run_tiffinfo image_file
       next if tiffinfo.nil?
 
@@ -31,15 +31,15 @@ class TIFFValidator < Stage
     begin
       info = TIFF.new(image_file.path).info
     rescue StandardError => e
-      add_error Error.new(e.message, image_file.barcode, image_file.file)
+      add_error Error.new(e.message, image_file.objid, image_file.file)
       return nil
     end
     log info[:cmd], info[:time]
     info[:warnings].each do |err|
-      add_warning Error.new(err, image_file.barcode, image_file.file)
+      add_warning Error.new(err, image_file.objid, image_file.file)
     end
     info[:errors].each do |err|
-      add_error Error.new(err, image_file.barcode, image_file.file)
+      add_error Error.new(err, image_file.objid, image_file.file)
     end
     info
   end
@@ -83,6 +83,6 @@ class TIFFValidator < Stage
   end
 
   def image_error(image_file, err)
-    add_error Error.new(err, image_file.barcode, image_file.path)
+    add_error Error.new(err, image_file.objid, image_file.path)
   end
 end

--- a/lib/tiff.rb
+++ b/lib/tiff.rb
@@ -5,6 +5,7 @@ require 'command'
 
 # TIFF Validation Stage
 class TIFF
+  TIFFTAG_DOCUMENTNAME = 269
   TIFFTAG_MAKE = 271
   TIFFTAG_MODEL = 272
   TIFFTAG_ORIENTATION = 274

--- a/query.rb
+++ b/query.rb
@@ -69,22 +69,22 @@ end
 tool = QueryTool.new(processor)
 
 COMMANDS = ['agenda', 'barcodes', 'errors', 'exit', 'help', 'ls', 'metadata',
-            'quit', 'run', 'status', '?'].freeze
+            'objects', 'quit', 'run', 'status', '?'].freeze
 COMMAND_SUMMARY = <<~COMMANDS
-  COMMAND            SUMMARY                 ALIAS
-  ==============================================================
-  barcodes           List shipment barcodes  ls
-  errors [BARCODE]   List shipment errors
-  help               Print this message      ?
+  COMMAND            SUMMARY                   ALIAS
+  ==========================================================
+  errors [OBJID]     List shipment errors
+  help               Print this message        ?
   fixity             Show fixity summary
-  quit               Quit the program        exit
+  objects            List shipment object ids  barcodes, ls
+  quit               Quit the program          exit
   run                Run processor
   status             Query shipment status
-  warnings [BARCODE] List shipment warnings
-  ==============================================================
+  warnings [OBJID]   List shipment warnings
+  ===========================================================
 COMMANDS
 
-completions = COMMANDS + processor.shipment.barcodes
+completions = COMMANDS + processor.shipment.objids
 Readline.completion_append_character = ' '
 Readline.completion_proc = proc do |str|
   completions.grep(/^#{Regexp.escape(str)}/)
@@ -97,8 +97,8 @@ begin
       case cmd
       when 'agenda'
         tool.agenda_cmd
-      when 'barcodes', 'ls'
-        tool.barcodes_cmd
+      when 'objects', 'barcodes', 'ls'
+        tool.objids_cmd
       when 'errors'
         tool.errors_cmd(*args)
       when 'help', '?'

--- a/shipments.rb
+++ b/shipments.rb
@@ -67,8 +67,8 @@ ARGV.each do |arg|
     end
     tool = QueryTool.new(processor)
     status = processor.errors.none? ? 'OK'.green : 'ERRORS'.red
-    objects = tool.pluralize processor.shipment.barcodes.count, 'object'
-    status += " (#{processor.shipment.barcodes.count} #{objects})"
+    objects = tool.pluralize processor.shipment.objids.count, 'object'
+    status += " (#{processor.shipment.objids.count} #{objects})"
     statuses[arg] = status
   rescue JSON::ParserError => e
     statuses[arg] = "Can't parse #{shipment.status_file}: #{e}".red

--- a/test/agenda_test.rb
+++ b/test/agenda_test.rb
@@ -25,9 +25,9 @@ class AgendaTest < Minitest::Test
       test_shipment = test_shipment_class.new(dir, spec)
       processor = Processor.new(test_shipment.directory, opts)
       agenda = Agenda.new processor.shipment, processor.stages
-      assert_equal processor.shipment.barcodes,
+      assert_equal processor.shipment.objids,
                    agenda.for_stage(processor.stages[0]),
-                   'first stage has all shipment barcodes'
+                   'first stage has all shipment objids'
     }
     generate_tests 'for_stage', test_proc
   end
@@ -38,13 +38,13 @@ class AgendaTest < Minitest::Test
       test_shipment = test_shipment_class.new(dir, spec)
       processor = Processor.new(test_shipment.directory, opts)
       agenda = Agenda.new processor.shipment, processor.stages
-      err = Error.new 'test error', processor.shipment.barcodes[0],
+      err = Error.new 'test error', processor.shipment.objids[0],
                       '00000001.tif'
       processor.stages[0].add_error err
       agenda.update processor.stages[0]
-      assert_equal processor.shipment.barcodes[1..],
+      assert_equal processor.shipment.objids[1..],
                    agenda.for_stage(processor.stages[1]),
-                   'subsequent stage has one less barcode'
+                   'subsequent stage has one less objid'
     }
     generate_tests 'update', test_proc
   end
@@ -59,7 +59,7 @@ class AgendaTest < Minitest::Test
       processor.stages[0].add_error err
       agenda.update processor.stages[0]
       assert_equal 0, agenda.for_stage(processor.stages[1]).count,
-                   'subsequent stage has no barcodes'
+                   'subsequent stage has no objids'
     }
     generate_tests 'update_fatal_error', test_proc
   end

--- a/test/bin/fake_feed_validate.pl
+++ b/test/bin/fake_feed_validate.pl
@@ -11,27 +11,27 @@ if ($ENV{FAKE_FEED_VALIDATE_CRASH}) {
 }
 
 if ($ENV{FAKE_FEED_VALIDATE_FAIL}) {
-  my $barcode_file = $ENV{FAKE_FEED_VALIDATE_FAIL} || '00000000000000/00000001.tif';
-  my @parts = split '/', $barcode_file;
+  my $objid_file = $ENV{FAKE_FEED_VALIDATE_FAIL} || '00000000000000/00000001.tif';
+  my @parts = split '/', $objid_file;
   my $file = pop @parts;
-  my $barcode = join '/', @parts;
+  my $objid = join '/', @parts;
   print <<END
-\e[1;33m15640: WARN - Validation failed\tobjid: $barcode\tnamespace: mdp\tfile: $file\tfield: image orientation\tdetail: This checks that the orientation in which the image should be displayed matches the \"natural\" order of pixels in the image. If not, this can be remediated by setting the value to 1 (normal) and rotating the image as needed.\e[0m
-\e[1;31m15640: ERROR - Missing field value\tobjid: $barcode\tnamespace: mdp\tfile: $file\tfield: in XMP - tiff:Artist\tremediable: 1\e[0m
-\e[1;31m15640: ERROR - File validation failed\tnamespace: mdp\tobjid: $barcode\tstage: HTFeed::VolumeValidator\tfile: $file\e[0m
+\e[1;33m15640: WARN - Validation failed\tobjid: $objid\tnamespace: mdp\tfile: $file\tfield: image orientation\tdetail: This checks that the orientation in which the image should be displayed matches the \"natural\" order of pixels in the image. If not, this can be remediated by setting the value to 1 (normal) and rotating the image as needed.\e[0m
+\e[1;31m15640: ERROR - Missing field value\tobjid: $objid\tnamespace: mdp\tfile: $file\tfield: in XMP - tiff:Artist\tremediable: 1\e[0m
+\e[1;31m15640: ERROR - File validation failed\tnamespace: mdp\tobjid: $objid\tstage: HTFeed::VolumeValidator\tfile: $file\e[0m
 failure!
 END
 }
 # Recent versions of feed are more verbose
 elsif ($ENV{FAKE_NEW_FEED_VALIDATE_FAIL}) {
-  my $barcode_file = $ENV{FAKE_NEW_FEED_VALIDATE_FAIL} || '00000000000000/00000001.tif';
-  my @parts = split '/', $barcode_file;
+  my $objid_file = $ENV{FAKE_NEW_FEED_VALIDATE_FAIL} || '00000000000000/00000001.tif';
+  my @parts = split '/', $objid_file;
   my $file = pop @parts;
-  my $barcode = join '/', @parts;
+  my $objid = join '/', @parts;
   print <<END
-\e[1;33mMay 21 11:56:08 Computer.local ../feed/bin/validate_images.pl[87997]: WARN - Validation failed\tobjid: $barcode\tnamespace: mdp\tfile: $file\tfield: image orientation\tdetail: This checks that the orientation in which the image should be displayed matches the \"natural\" order of pixels in the image. If not, this can be remediated by setting the value to 1 (normal) and rotating the image as needed.\e[0m
-\e[1;31mMay 21 11:56:08 Computer.local ../feed/bin/validate_images.pl[87997]: ERROR - Missing field value\tobjid: $barcode\tnamespace: mdp\tfile: $file\tfield: in XMP - tiff:Artist\tremediable: 1\e[0m
-\e[1;31mMay 21 11:56:08 Computer.local ../feed/bin/validate_images.pl[87997]: ERROR - File validation failed\tnamespace: mdp\tobjid: $barcode\tstage: HTFeed::VolumeValidator\tfile: $file\e[0m
+\e[1;33mMay 21 11:56:08 Computer.local ../feed/bin/validate_images.pl[87997]: WARN - Validation failed\tobjid: $objid\tnamespace: mdp\tfile: $file\tfield: image orientation\tdetail: This checks that the orientation in which the image should be displayed matches the \"natural\" order of pixels in the image. If not, this can be remediated by setting the value to 1 (normal) and rotating the image as needed.\e[0m
+\e[1;31mMay 21 11:56:08 Computer.local ../feed/bin/validate_images.pl[87997]: ERROR - Missing field value\tobjid: $objid\tnamespace: mdp\tfile: $file\tfield: in XMP - tiff:Artist\tremediable: 1\e[0m
+\e[1;31mMay 21 11:56:08 Computer.local ../feed/bin/validate_images.pl[87997]: ERROR - File validation failed\tnamespace: mdp\tobjid: $objid\tstage: HTFeed::VolumeValidator\tfile: $file\e[0m
 failure!
 END
 }

--- a/test/compressor_test.rb
+++ b/test/compressor_test.rb
@@ -32,11 +32,11 @@ class CompressorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       stage.run!
       assert_equal(0, stage.errors.count, 'stage runs without errors')
       tiff = File.join(shipment.directory,
-                       shipment.barcode_to_path(shipment.barcodes[0]),
+                       shipment.objid_to_path(shipment.objids[0]),
                        '00000001.tif')
       assert File.exist?(tiff), '00000001.tif exists'
       jp2 = File.join(shipment.directory,
-                      shipment.barcode_to_path(shipment.barcodes[0]),
+                      shipment.objid_to_path(shipment.objids[0]),
                       '00000002.jp2')
       assert File.exist?(jp2), '00000002.jp2 exists'
     }
@@ -48,7 +48,7 @@ class CompressorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       test_shipment = test_shipment_class.new(dir, 'BC T bitonal 1')
       shipment = shipment_class.new(test_shipment.directory)
       tiff = File.join(shipment.directory,
-                       shipment.barcode_to_path(shipment.barcodes[0]),
+                       shipment.objid_to_path(shipment.objids[0]),
                        '00000001.tif')
       stage = Compressor.new(shipment, config: opts.merge(@config))
       stage.send(:write_tiff_date_time, tiff)
@@ -64,13 +64,13 @@ class CompressorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       test_shipment = test_shipment_class.new(dir, 'BC T contone 1')
       shipment = shipment_class.new(test_shipment.directory)
       tiff = File.join(shipment.directory,
-                       shipment.barcode_to_path(shipment.barcodes[0]),
+                       shipment.objid_to_path(shipment.objids[0]),
                        '00000001.tif')
       `tiffset -s 306 '2000:11:11 11:11:11' #{tiff}`
       stage = Compressor.new(shipment, config: opts.merge(@config))
       stage.run!
       jp2 = File.join(shipment.directory,
-                      shipment.barcode_to_path(shipment.barcodes[0]),
+                      shipment.objid_to_path(shipment.objids[0]),
                       '00000001.jp2')
       exif_data = `exiftool #{jp2}`
       assert_match(%r{Date/Time\sModified\s*:\s*2000:11:11\s11:11:11},
@@ -86,9 +86,9 @@ class CompressorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       stage = Compressor.new(shipment, config: opts.merge(@config))
       stage.run!
       jp2 = File.join(shipment.directory,
-                      shipment.barcode_to_path(shipment.barcodes[0]),
+                      shipment.objid_to_path(shipment.objids[0]),
                       '00000001.jp2')
-      doc_name = File.join(shipment.barcode_to_path(shipment.barcodes[0]),
+      doc_name = File.join(shipment.objid_to_path(shipment.objids[0]),
                            '00000001.jp2')
       exif_data = `exiftool #{jp2}`
       assert_match(/Source\s*:\s*#{Regexp.escape doc_name}/,
@@ -127,7 +127,7 @@ class CompressorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       test_shipment = test_shipment_class.new(dir, 'BC T contone 1')
       shipment = shipment_class.new(test_shipment.directory)
       tiff = File.join(shipment.directory,
-                       shipment.barcode_to_path(shipment.barcodes[0]),
+                       shipment.objid_to_path(shipment.objids[0]),
                        '00000001.tif')
       `convert #{tiff} -alpha on #{tiff}`
       stage = Compressor.new(shipment, config: opts.merge(@config))
@@ -142,7 +142,7 @@ class CompressorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       test_shipment = test_shipment_class.new(dir, 'BC T contone 1')
       shipment = shipment_class.new(test_shipment.directory)
       tiff = File.join(shipment.directory,
-                       shipment.barcode_to_path(shipment.barcodes[0]),
+                       shipment.objid_to_path(shipment.objids[0]),
                        '00000001.tif')
       profile_path = File.join(Fixtures::TEST_FIXTURES_PATH, 'sRGB2014.icc')
       `convert #{tiff} -profile #{profile_path} #{tiff}`
@@ -158,7 +158,7 @@ class CompressorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       test_shipment = test_shipment_class.new(dir, 'BC T bitonal 1')
       shipment = shipment_class.new(test_shipment.directory)
       tiff = File.join(shipment.directory,
-                       shipment.barcode_to_path(shipment.barcodes[0]),
+                       shipment.objid_to_path(shipment.objids[0]),
                        '00000001.tif')
       `tiffset -s 305 'BOGUS SOFTWARE v1.0' #{tiff}`
       stage = Compressor.new(shipment, config: opts.merge(@config))

--- a/test/dlxs_compressor_test.rb
+++ b/test/dlxs_compressor_test.rb
@@ -26,15 +26,15 @@ class DLXSCompressorTest < Minitest::Test
       stage = DLXSCompressor.new(shipment, config: opts.merge(@config))
       stage.run!
       tiff = File.join(shipment.directory,
-                       shipment.barcode_to_path(shipment.barcodes[0]),
+                       shipment.objid_to_path(shipment.objids[0]),
                        '00000001.tif')
       assert File.exist?(tiff), '00000001.tif exists'
       jp2 = File.join(shipment.directory,
-                      shipment.barcode_to_path(shipment.barcodes[0]),
+                      shipment.objid_to_path(shipment.objids[0]),
                       '00000001.jp2')
       refute File.exist?(jp2), '00000001.jp2 does not exist'
       jp2 = File.join(shipment.directory,
-                      shipment.barcode_to_path(shipment.barcodes[0]),
+                      shipment.objid_to_path(shipment.objids[0]),
                       'p0000001.jp2')
       assert File.exist?(jp2), 'p0000001.jp2 exists'
     }

--- a/test/error_test.rb
+++ b/test/error_test.rb
@@ -35,7 +35,7 @@ class ErrorTest < Minitest::Test
     err2 = JSON.load(err.to_json)
     # rubocop:enable Security/JSONLoad
     assert err.description == err2.description &&
-           err.barcode == err2.barcode &&
+           err.objid == err2.objid &&
            err.path == err2.path,
            'JSON round trip'
   end

--- a/test/jhove_test.rb
+++ b/test/jhove_test.rb
@@ -46,7 +46,7 @@ class JHOVETest < Minitest::Test
   def self.gen_error # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     test_proc = proc { |shipment_class, test_shipment_class, dir, opts|
       setup_test(shipment_class, test_shipment_class, dir, opts)
-      tiff = File.join(@shipment.barcode_to_path(@shipment.barcodes[0]),
+      tiff = File.join(@shipment.objid_to_path(@shipment.objids[0]),
                        '00000001.tif')
       %w[FAKE_FEED_VALIDATE_FAIL FAKE_NEW_FEED_VALIDATE_FAIL].each do |var|
         ENV[var] = tiff

--- a/test/pagination_check_test.rb
+++ b/test/pagination_check_test.rb
@@ -35,8 +35,8 @@ class PaginationCheckTest < Minitest::Test
       stage = PaginationCheck.new(shipment, config: opts.merge(@config))
       stage.run!
       assert(stage.errors.count == 1, 'one missing page error')
-      assert_equal(stage.errors[0].barcode, shipment.barcodes[0],
-                   'error barcode is shipment barcode')
+      assert_equal(stage.errors[0].objid, shipment.objids[0],
+                   'error objid is shipment objid')
       assert_match(/missing/, stage.errors[0].description,
                    'error contains "missing"')
     }

--- a/test/postflight_test.rb
+++ b/test/postflight_test.rb
@@ -47,12 +47,12 @@ class PostflightTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       stage = Preflight.new(shipment, config: opts.merge(@config))
       stage.run!
       FileUtils.rm_r(File.join(shipment.directory,
-                               shipment.barcode_to_path(shipment.barcodes[0])),
+                               shipment.objid_to_path(shipment.objids[0])),
                      force: true)
       stage = Postflight.new(shipment, config: opts.merge(@config))
       stage.run!
       assert stage.errors.any? { |e| /removed/.match? e.to_s },
-             'stage gripes about removed barcode'
+             'stage gripes about removed objid'
     }
     generate_tests 'metadata_mismatch_removed', test_proc
   end
@@ -64,13 +64,13 @@ class PostflightTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       shipment = shipment_class.new(test_shipment.directory)
       stage = Preflight.new(shipment, config: opts.merge(@config))
       stage.run!
-      new_barcode = test_shipment_class.generate_barcode
+      new_objid = test_shipment_class.generate_objid
       FileUtils.mkdir_p File.join(shipment.directory,
-                                  shipment.barcode_to_path(new_barcode))
+                                  shipment.objid_to_path(new_objid))
       stage = Postflight.new(shipment, config: opts.merge(@config))
       stage.run!
       assert stage.errors.any? { |e| /added/i.match? e.to_s },
-             'stage gripes about added barcode'
+             'stage gripes about added objid'
     }
     generate_tests 'metadata_mismatch_added', test_proc
   end
@@ -81,7 +81,7 @@ class PostflightTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       shipment = shipment_class.new(test_shipment.directory)
       stage = Preflight.new(shipment, config: opts.merge(@config))
       stage.run!
-      tiff = File.join(shipment.barcode_to_path(shipment.barcodes[0]),
+      tiff = File.join(shipment.objid_to_path(shipment.objids[0]),
                        '00000001.tif')
       %w[FAKE_FEED_VALIDATE_FAIL FAKE_NEW_FEED_VALIDATE_FAIL].each do |var|
         ENV[var] = tiff
@@ -123,7 +123,7 @@ class PostflightTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       stage = Preflight.new(shipment, config: opts.merge(@config))
       stage.run!
       tiff = File.join(shipment.source_directory,
-                       shipment.barcode_to_path(shipment.barcodes[0]),
+                       shipment.objid_to_path(shipment.objids[0]),
                        '00000001.tif')
       `echo 'test' > #{tiff}`
       stage = Postflight.new(shipment, config: opts.merge(@config))
@@ -141,7 +141,7 @@ class PostflightTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       stage = Preflight.new(shipment, config: opts.merge(@config))
       stage.run!
       tiff = File.join(shipment.source_directory,
-                       shipment.barcode_to_path(shipment.barcodes[0]),
+                       shipment.objid_to_path(shipment.objids[0]),
                        '00000001.tif')
       FileUtils.rm tiff
       stage = Postflight.new(shipment, config: opts.merge(@config))
@@ -159,7 +159,7 @@ class PostflightTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       stage = Preflight.new(shipment, config: opts.merge(@config))
       stage.run!
       tiff = File.join(shipment.source_directory,
-                       shipment.barcode_to_path(shipment.barcodes[0]),
+                       shipment.objid_to_path(shipment.objids[0]),
                        '00000003.tif')
       `echo 'test' > #{tiff}`
       stage = Postflight.new(shipment, config: opts.merge(@config))

--- a/test/preflight_test.rb
+++ b/test/preflight_test.rb
@@ -32,14 +32,14 @@ class PreflightTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       stage.run!
       assert_equal 0, stage.errors.count, 'stage runs without errors'
       assert_equal 2, shipment.metadata[:initial_barcodes].count,
-                   'correct number of initial barcodes in metadata'
+                   'correct number of initial objids in metadata'
       assert_equal 2, shipment.checksums.count,
                    'correct number of checksums in metadata'
     }
     generate_tests 'run', test_proc
   end
 
-  def self.gen_validate_barcode
+  def self.gen_validate_objid
     test_proc = proc { |shipment_class, test_shipment_class, dir, opts|
       test_shipment = test_shipment_class.new(dir, 'BBC T bitonal 1')
       shipment = shipment_class.new(test_shipment.directory)
@@ -49,7 +49,7 @@ class PreflightTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       # Different shipment classes will generate different warning messages
       assert_equal(1, stage.warnings.count, 'stage produces one warning')
     }
-    generate_tests 'validate_barcode', test_proc
+    generate_tests 'validate_objid', test_proc
   end
 
   def self.gen_remove_ds_store # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
@@ -57,7 +57,7 @@ class PreflightTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       test_shipment = test_shipment_class.new(dir, 'BC T bitonal 1')
       shipment = shipment_class.new(test_shipment.directory)
       ds_store = File.join(shipment.directory,
-                           shipment.barcode_to_path(shipment.barcodes[0]),
+                           shipment.objid_to_path(shipment.objids[0]),
                            '.DS_Store')
       FileUtils.touch(ds_store)
       assert(File.exist?(ds_store), '.DS_Store file created')
@@ -75,7 +75,7 @@ class PreflightTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       test_shipment = test_shipment_class.new(dir, 'BC T bitonal 1')
       shipment = shipment_class.new(test_shipment.directory)
       thumbs = File.join(shipment.directory,
-                         shipment.barcode_to_path(shipment.barcodes[0]),
+                         shipment.objid_to_path(shipment.objids[0]),
                          'Thumbs.db')
       FileUtils.touch(thumbs)
       assert File.exist?(thumbs), 'Thumbs.db file created'
@@ -109,7 +109,7 @@ class PreflightTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       test_shipment = test_shipment_class.new(dir, 'BC T bitonal 1')
       shipment = shipment_class.new(test_shipment.directory)
       thumbs = File.join(shipment.directory,
-                         shipment.barcode_to_path(shipment.barcodes[0]),
+                         shipment.objid_to_path(shipment.objids[0]),
                          'Thumbs.db')
       FileUtils.touch(thumbs)
       assert File.exist?(thumbs), 'Thumbs.db file created'
@@ -122,16 +122,16 @@ class PreflightTest < Minitest::Test # rubocop:disable Metrics/ClassLength
     generate_tests 'remove_toplevel_thumbs_db', test_proc
   end
 
-  def self.gen_barcode_directory_errors_and_warnings # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def self.gen_objid_directory_errors_and_warnings # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     test_proc = proc { |shipment_class, test_shipment_class, dir, opts|
       test_shipment = test_shipment_class.new(dir, 'BC F spurious_file')
       shipment = shipment_class.new(test_shipment.directory)
       checksum_md5 = File.join(shipment.directory,
-                               shipment.barcode_to_path(shipment.barcodes[0]),
+                               shipment.objid_to_path(shipment.objids[0]),
                                'checksum.md5')
       FileUtils.touch checksum_md5
       spurious_d = File.join(shipment.directory,
-                             shipment.barcode_to_path(shipment.barcodes[0]),
+                             shipment.objid_to_path(shipment.objids[0]),
                              'spurious_d')
       Dir.mkdir spurious_d
       stage = Preflight.new(shipment, config: opts.merge(@config))
@@ -139,11 +139,11 @@ class PreflightTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       assert stage.errors.any? { |e| /spurious_file/.match? e.to_s },
              'stage fails with unknown file'
       assert stage.errors.any? { |e| /spurious_d/.match? e.to_s },
-             'stage fails with barcode subdirectory'
+             'stage fails with objid subdirectory'
       assert stage.warnings.any? { |e| /ignored/i.match? e.to_s },
              'stage warns about ignored checksum.md5 file'
     }
-    generate_tests 'barcode_directory_errors_and_warnings', test_proc
+    generate_tests 'objid_directory_errors_and_warnings', test_proc
   end
 
   def self.gen_shipment_directory_errors # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
@@ -152,8 +152,8 @@ class PreflightTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       shipment = shipment_class.new(test_shipment.directory)
       stage = Preflight.new(shipment, config: opts.merge(@config))
       stage.run!
-      assert stage.errors.any? { |e| /no barcodes/.match? e.to_s },
-             'stage fails with no barcode directories'
+      assert stage.errors.any? { |e| /no objids/.match? e.to_s },
+             'stage fails with no objid directories'
       assert stage.errors.any? { |e| /spurious_file/.match? e.to_s },
              'stage fails with unknown file'
     }

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -61,8 +61,8 @@ class ProcessorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       capture_io do
         processor.run
       end
-      errs = processor.errors['Preflight'][processor.shipment.barcodes[0]]
-      warnings = processor.warnings['Preflight'][processor.shipment.barcodes[0]]
+      errs = processor.errors['Preflight'][processor.shipment.objids[0]]
+      warnings = processor.warnings['Preflight'][processor.shipment.objids[0]]
       assert errs.any? { |e| /no.TIFF/i.match? e.to_s },
              'Preflight fails with no TIFFs error'
       assert warnings.any? { |e| /\.DS_Store/.match? e.to_s },
@@ -95,7 +95,7 @@ class ProcessorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       end
       processor.write_status_file
       processor = Processor.new(test_shipment.directory, opts.merge(@options))
-      errs = processor.errors['TIFF Validator'][processor.shipment.barcodes[0]]
+      errs = processor.errors['TIFF Validator'][processor.shipment.objids[0]]
       assert_kind_of Error, errs[0],
                      'Error class reconstituted from status.json'
     }
@@ -113,8 +113,8 @@ class ProcessorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       FileUtils.copy_entry(test_shipment.directory, shipment_copy_dir)
       FileUtils.rm_r(test_shipment.directory, force: true)
       processor = Processor.new(shipment_copy_dir, opts.merge(@options))
-      assert_equal 1, processor.shipment.barcodes.count,
-                   'relocated shipment can access its barcodes'
+      assert_equal 1, processor.shipment.objids.count,
+                   'relocated shipment can access its objids'
       FileUtils.rm_r(shipment_copy_dir, force: true)
     }
     generate_tests 'move_status_file', test_proc
@@ -126,7 +126,7 @@ class ProcessorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       processor = Processor.new(test_shipment.directory, opts.merge(@options))
       shipment = processor.shipment
       tiff = File.join(shipment.directory,
-                       shipment.barcode_to_path(shipment.barcodes[0]),
+                       shipment.objid_to_path(shipment.objids[0]),
                        '00000001.tif')
       old_hash = Digest::SHA256.file(tiff).hexdigest
       shipment.setup_source_directory
@@ -217,12 +217,12 @@ class ProcessorErrorCorrectionTest < Minitest::Test
         processor.run
       end
       refute processor.errors.none?, 'error detected'
-      bad_barcode = test_shipment.ordered_barcodes[1]
-      tiff = File.join(processor.shipment.barcode_to_path(bad_barcode),
+      bad_objid = test_shipment.ordered_objids[1]
+      tiff = File.join(processor.shipment.objid_to_path(bad_objid),
                        '00000001.tif')
       old_checksum = processor.shipment.checksums[tiff]
       fixture = Fixtures.tiff_fixture('contone')
-      dest = File.join(processor.shipment.source_barcode_directory(bad_barcode),
+      dest = File.join(processor.shipment.source_objid_directory(bad_objid),
                        '00000001.tif')
       FileUtils.cp fixture, dest
       capture_io do

--- a/test/query_tool_test.rb
+++ b/test/query_tool_test.rb
@@ -35,8 +35,8 @@ class QueryToolTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       end
       out = out.decolorize
       processor.stages.each do |stage|
-        assert_match "#{stage.name}\n  (all barcodes)", out,
-                     "#{stage.name} all barcodes"
+        assert_match "#{stage.name}\n  (all objids)", out,
+                     "#{stage.name} all objids"
       end
     }
     generate_tests 'agenda_cmd', test_proc
@@ -58,34 +58,34 @@ class QueryToolTest < Minitest::Test # rubocop:disable Metrics/ClassLength
     generate_tests 'agenda_cmd_no_agenda', test_proc
   end
 
-  def self.gen_barcodes_cmd
+  def self.gen_objids_cmd
     test_proc = proc { |_shipment_class, test_shipment_class, dir, opts|
       test_shipment = test_shipment_class.new(dir, 'BC T contone 1')
       processor = Processor.new(test_shipment.directory, opts.merge(@options))
       tool = QueryTool.new(processor)
       out, _err = capture_io do
-        tool.barcodes_cmd
+        tool.objids_cmd
       end
-      assert_match(test_shipment.barcodes[0], out, 'barcode is listed')
+      assert_match(test_shipment.objids[0], out, 'objid is listed')
     }
-    generate_tests 'barcodes_cmd', test_proc
+    generate_tests 'objids_cmd', test_proc
   end
 
-  def self.gen_barcodes_cmd_with_errors # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def self.gen_objids_cmd_with_errors # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     test_proc = proc { |_shipment_class, test_shipment_class, dir, opts|
       test_shipment = test_shipment_class.new(dir, 'BC T bad_16bps 1')
       processor = Processor.new(test_shipment.directory, opts.merge(@options))
       stage = processor.stages[0]
-      stage.add_error Error.new('err', processor.shipment.barcodes[0],
+      stage.add_error Error.new('err', processor.shipment.objids[0],
                                 '00000001.tif')
       tool = QueryTool.new(processor)
       out, _err = capture_io do
-        tool.barcodes_cmd
+        tool.objids_cmd
       end
-      assert_match("#{processor.shipment.barcodes[0]} ERROR", out.decolorize,
-                   'barcode is listed with error')
+      assert_match("#{processor.shipment.objids[0]} ERROR", out.decolorize,
+                   'objid is listed with error')
     }
-    generate_tests 'barcodes_cmd_with_errors', test_proc
+    generate_tests 'objids_cmd_with_errors', test_proc
   end
 
   def self.gen_errors_cmd # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
@@ -95,23 +95,23 @@ class QueryToolTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       processor = Processor.new(test_shipment.directory, opts.merge(@options))
       shipment = processor.shipment
       stage = processor.stages[0]
-      stage.add_error Error.new('err 1', shipment.barcodes[0], '00000001.tif')
-      stage.add_error Error.new('err 2', shipment.barcodes[1], '00000002.tif')
+      stage.add_error Error.new('err 1', shipment.objids[0], '00000001.tif')
+      stage.add_error Error.new('err 2', shipment.objids[1], '00000002.tif')
       tool = QueryTool.new(processor)
       out, _err = capture_io do
         tool.errors_cmd
       end
       assert_match '00000001.tif', out, 'reports errors for both files'
-      assert_match shipment.barcodes[0], out, 'reports errors for both barcodes'
+      assert_match shipment.objids[0], out, 'reports errors for both objids'
       assert_match '00000002.tif', out, 'reports errors for both files'
-      assert_match shipment.barcodes[1], out, 'reports errors for both barcodes'
+      assert_match shipment.objids[1], out, 'reports errors for both objids'
       out, _err = capture_io do
-        tool.errors_cmd shipment.barcodes[0]
+        tool.errors_cmd shipment.objids[0]
       end
       assert_match '00000001.tif', out, 'reports error for first file'
-      assert_match shipment.barcodes[0], out, 'reports error for first barcode'
+      assert_match shipment.objids[0], out, 'reports error for first objid'
       refute_match '00000002.tif', out, 'no error for second file'
-      refute_match shipment.barcodes[1], out, 'no error for second barcode'
+      refute_match shipment.objids[1], out, 'no error for second objid'
     }
     generate_tests 'errors_cmd', test_proc
   end
@@ -123,23 +123,23 @@ class QueryToolTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       processor = Processor.new(test_shipment.directory, opts.merge(@options))
       shipment = processor.shipment
       stage = processor.stages[0]
-      stage.add_warning Error.new('err 1', shipment.barcodes[0], '00000001.tif')
-      stage.add_warning Error.new('err 2', shipment.barcodes[1], '00000002.tif')
+      stage.add_warning Error.new('err 1', shipment.objids[0], '00000001.tif')
+      stage.add_warning Error.new('err 2', shipment.objids[1], '00000002.tif')
       tool = QueryTool.new(processor)
       out, _err = capture_io do
         tool.warnings_cmd
       end
       assert_match '00000001.tif', out, 'warnings for both files'
-      assert_match shipment.barcodes[0], out, 'warnings for both barcodes'
+      assert_match shipment.objids[0], out, 'warnings for both objids'
       assert_match '00000002.tif', out, 'warnings for both files'
-      assert_match shipment.barcodes[1], out, 'warnings for both barcodes'
+      assert_match shipment.objids[1], out, 'warnings for both objids'
       out, _err = capture_io do
-        tool.warnings_cmd shipment.barcodes[0]
+        tool.warnings_cmd shipment.objids[0]
       end
       assert_match '00000001.tif', out, 'warning for first file'
-      assert_match shipment.barcodes[0], out, 'warning for first barcode'
+      assert_match shipment.objids[0], out, 'warning for first objid'
       refute_match '00000002.tif', out, 'no warning for second file'
-      refute_match shipment.barcodes[1], out, 'no warning for second barcode'
+      refute_match shipment.objids[1], out, 'no warning for second objid'
     }
     generate_tests 'warnings_cmd', test_proc
   end
@@ -174,26 +174,26 @@ class QueryToolTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       shipment = processor.shipment
       shipment.setup_source_directory
       shipment.checksum_source_directory
-      barcode = shipment.barcodes[0]
-      barcode_path = shipment.barcode_to_path(barcode)
+      objid = shipment.objids[0]
+      objid_path = shipment.objid_to_path(objid)
       # Add 00000001.tif, change 00000002.tif, and remove 00000003.tif
-      tiff1 = File.join(shipment.source_directory, barcode_path, '00000001.tif')
+      tiff1 = File.join(shipment.source_directory, objid_path, '00000001.tif')
       refute File.exist?(tiff1), '(make sure 00000001.tif does not exist)'
       `/bin/echo -n 'test' > #{tiff1}`
-      tiff2 = File.join(shipment.source_directory, barcode_path, '00000002.tif')
+      tiff2 = File.join(shipment.source_directory, objid_path, '00000002.tif')
       `/bin/echo -n 'test' > #{tiff2}`
-      tiff3 = File.join(shipment.source_directory, barcode_path, '00000003.tif')
+      tiff3 = File.join(shipment.source_directory, objid_path, '00000003.tif')
       FileUtils.rm tiff3
       tool = QueryTool.new(processor)
       out, _err = capture_io do
         tool.fixity_cmd
       end
       out = out.decolorize
-      assert_match "Added\n  #{File.join(barcode_path, '00000001.tif')}",
+      assert_match "Added\n  #{File.join(objid_path, '00000001.tif')}",
                    out, '00000001.tif added'
-      assert_match "Changed\n  #{File.join(barcode_path, '00000002.tif')}",
+      assert_match "Changed\n  #{File.join(objid_path, '00000002.tif')}",
                    out, '00000002.tif changed'
-      assert_match "Removed\n  #{File.join(barcode_path, '00000003.tif')}",
+      assert_match "Removed\n  #{File.join(objid_path, '00000003.tif')}",
                    out, '00000003.tif removed'
     }
     generate_tests 'fixity_cmd', test_proc

--- a/test/shipment_test.rb
+++ b/test/shipment_test.rb
@@ -31,13 +31,13 @@ class ShipmentTest < Minitest::Test # rubocop:disable Metrics/ClassLength
     generate_tests 'directory', test_proc
   end
 
-  def self.gen_path_components_from_barcode # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def self.gen_path_components_from_objid # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     test_proc = proc { |shipment_class, test_shipment_class, dir, _opts|
       test_shipment = test_shipment_class.new(dir, 'BC')
       shipment = shipment_class.new(test_shipment.directory)
-      components = shipment.barcode_to_path(shipment.barcodes[0])
+      components = shipment.objid_to_path(shipment.objids[0])
       assert_equal components.count, shipment_class::PATH_COMPONENTS,
-                   'barcode path component count = PATH_COMPONENTS'
+                   'objid path component count = PATH_COMPONENTS'
       path = [shipment.directory]
       while (component = components.shift)
         path << component
@@ -45,7 +45,7 @@ class ShipmentTest < Minitest::Test # rubocop:disable Metrics/ClassLength
                "#{File.join(path)} is a directory"
       end
     }
-    generate_tests 'barcode_to_path', test_proc
+    generate_tests 'objid_to_path', test_proc
   end
 
   def self.gen_source_directory # rubocop:disable Metrics/MethodLength
@@ -76,16 +76,16 @@ class ShipmentTest < Minitest::Test # rubocop:disable Metrics/ClassLength
     generate_tests 'tmp_directory', test_proc
   end
 
-  def self.gen_source_barcodes
+  def self.gen_source_objids
     test_proc = proc { |shipment_class, test_shipment_class, dir, _opts|
       test_shipment = test_shipment_class.new(dir, 'BC T contone 1')
       shipment = shipment_class.new(test_shipment.directory)
       shipment.setup_source_directory
-      assert_equal shipment.barcodes[0],
-                   shipment.source_barcodes[0],
-                   'barcode and source barcode are the same'
+      assert_equal shipment.objids[0],
+                   shipment.source_objids[0],
+                   'objid and source objid are the same'
     }
-    generate_tests 'source_barcodes', test_proc
+    generate_tests 'source_objids', test_proc
   end
 
   def self.gen_image_files # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
@@ -96,7 +96,7 @@ class ShipmentTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       files = shipment.image_files
       assert_equal 3, files.count, '3 image files'
       assert_kind_of ImageFile, files[0], 'produces ImageFile'
-      refute_nil files[0].barcode, 'ImageFile barcode is not nil'
+      refute_nil files[0].objid, 'ImageFile objid is not nil'
       refute_nil files[0].path, 'ImageFile path is not nil'
     }
     generate_tests 'image_files', test_proc
@@ -108,12 +108,12 @@ class ShipmentTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       shipment = shipment_class.new(test_shipment.directory)
       shipment.setup_source_directory
       path = File.join(shipment.directory,
-                       shipment.barcode_to_path(shipment.barcodes[0]))
-      assert File.directory?(path), 'source/barcode directory created'
+                       shipment.objid_to_path(shipment.objids[0]))
+      assert File.directory?(path), 'source/objid directory created'
       path = File.join(shipment.directory,
-                       shipment.barcode_to_path(shipment.barcodes[0]),
+                       shipment.objid_to_path(shipment.objids[0]),
                        '00000001.tif')
-      assert File.exist?(path), 'source/barcode/00000001.tif created'
+      assert File.exist?(path), 'source/objid/00000001.tif created'
     }
     generate_tests 'setup_source_directory', test_proc
   end
@@ -124,7 +124,7 @@ class ShipmentTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       shipment = shipment_class.new(test_shipment.directory)
       shipment.setup_source_directory
       tiff = File.join(shipment.directory,
-                       shipment.barcode_to_path(shipment.barcodes[0]),
+                       shipment.objid_to_path(shipment.objids[0]),
                        '00000001.tif')
       tiff_size = File.size tiff
       `/bin/echo -n 'test' > #{tiff}`
@@ -143,15 +143,15 @@ class ShipmentTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       shipment = shipment_class.new(test_shipment.directory)
       shipment.setup_source_directory
       tiff0 = File.join(shipment.directory,
-                        shipment.barcode_to_path(shipment.barcodes[0]),
+                        shipment.objid_to_path(shipment.objids[0]),
                         '00000001.tif')
       tiff0_size = File.size tiff0
       `/bin/echo -n 'test' > #{tiff0}`
       tiff1 = File.join(shipment.directory,
-                        shipment.barcode_to_path(shipment.barcodes[1]),
+                        shipment.objid_to_path(shipment.objids[1]),
                         '00000001.tif')
       `/bin/echo -n 'test' > #{tiff1}`
-      shipment.restore_from_source_directory [shipment.barcodes[0]]
+      shipment.restore_from_source_directory [shipment.objids[0]]
       assert_equal tiff0_size, File.size(tiff0),
                    'TIFF file in restored directory at original size'
       assert_equal 4, File.size(tiff1),
@@ -179,33 +179,33 @@ class ShipmentTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       shipment.checksum_source_directory
       # Add 00000001.tif, change 00000002.tif, and remove 00000003.tif
       tiff1 = File.join(shipment.source_directory,
-                        shipment.barcode_to_path(shipment.barcodes[0]),
+                        shipment.objid_to_path(shipment.objids[0]),
                         '00000001.tif')
       refute File.exist?(tiff1), '(make sure 00000001.tif does not exist)'
       `/bin/echo -n 'test' > #{tiff1}`
       tiff2 = File.join(shipment.source_directory,
-                        shipment.barcode_to_path(shipment.barcodes[0]),
+                        shipment.objid_to_path(shipment.objids[0]),
                         '00000002.tif')
       `/bin/echo -n 'test' > #{tiff2}`
       tiff3 = File.join(shipment.source_directory,
-                        shipment.barcode_to_path(shipment.barcodes[0]),
+                        shipment.objid_to_path(shipment.objids[0]),
                         '00000003.tif')
       FileUtils.rm tiff3
       fixity = shipment.fixity_check
       assert_equal 1, fixity[:added].count, 'one file added'
-      barcode_file = File.join(shipment.barcode_to_path(shipment.barcodes[0]),
-                               '00000001.tif')
-      assert_equal barcode_file, fixity[:added][0].barcode_file,
+      objid_file = File.join(shipment.objid_to_path(shipment.objids[0]),
+                             '00000001.tif')
+      assert_equal objid_file, fixity[:added][0].objid_file,
                    '00000001.tif added'
       assert_equal 1, fixity[:changed].count, 'one file changed'
-      barcode_file = File.join(shipment.barcode_to_path(shipment.barcodes[0]),
-                               '00000002.tif')
-      assert_equal barcode_file, fixity[:changed][0].barcode_file,
+      objid_file = File.join(shipment.objid_to_path(shipment.objids[0]),
+                             '00000002.tif')
+      assert_equal objid_file, fixity[:changed][0].objid_file,
                    '00000002.tif changed'
       assert_equal 1, fixity[:removed].count, 'one file changed'
-      barcode_file = File.join(shipment.barcode_to_path(shipment.barcodes[0]),
-                               '00000003.tif')
-      assert_equal barcode_file, fixity[:removed][0].barcode_file,
+      objid_file = File.join(shipment.objid_to_path(shipment.objids[0]),
+                             '00000003.tif')
+      assert_equal objid_file, fixity[:removed][0].objid_file,
                    '00000003.tif removed'
     }
     generate_tests 'fixity_check', test_proc

--- a/test/stage_test.rb
+++ b/test/stage_test.rb
@@ -52,7 +52,7 @@ class StageTest < Minitest::Test
       shipment = shipment_class.new(test_shipment.directory)
       stage = Stage.new(shipment, config: @config.merge(opts))
       temp = File.join(shipment.directory,
-                       shipment.barcode_to_path(shipment.barcodes[0]),
+                       shipment.objid_to_path(shipment.objids[0]),
                        'temp.txt')
       FileUtils.touch(temp)
       stage.delete_on_success temp

--- a/test/tagger_test.rb
+++ b/test/tagger_test.rb
@@ -48,7 +48,7 @@ class TaggerTest < Minitest::Test
       test_shipment = test_shipment_class.new(dir, 'BC T bitonal 1')
       shipment = shipment_class.new(test_shipment.directory)
       tiff = File.join(shipment.directory,
-                       shipment.barcode_to_path(shipment.barcodes[0]),
+                       shipment.objid_to_path(shipment.objids[0]),
                        '00000001.tif')
       config = Config.new({ no_progress: true, tagger_artist: 'bentley' })
       stage = Tagger.new(shipment, config: config.merge(opts))
@@ -64,7 +64,7 @@ class TaggerTest < Minitest::Test
       test_shipment = test_shipment_class.new(dir, 'BC T bitonal 1')
       shipment = shipment_class.new(test_shipment.directory)
       tiff = File.join(shipment.directory,
-                       shipment.barcode_to_path(shipment.barcodes[0]),
+                       shipment.objid_to_path(shipment.objids[0]),
                        '00000001.tif')
       config = Config.new({ no_progress: true, tagger_scanner: 'copibookv' })
       stage = Tagger.new(shipment, config: config.merge(opts))
@@ -83,7 +83,7 @@ class TaggerTest < Minitest::Test
       test_shipment = test_shipment_class.new(dir, 'BC T bitonal 1')
       shipment = shipment_class.new(test_shipment.directory)
       tiff = File.join(shipment.directory,
-                       shipment.barcode_to_path(shipment.barcodes[0]),
+                       shipment.objid_to_path(shipment.objids[0]),
                        '00000001.tif')
       config = Config.new({ no_progress: true, tagger_software: 'limb' })
       stage = Tagger.new(shipment, config: config.merge(opts))
@@ -118,7 +118,7 @@ class TaggerCustomTagTest < Minitest::Test
       assert stage.warnings.any? { |e| /custom\sartist/i.match? e.to_s },
              'warns about custom artist string'
       tiff = File.join(shipment.directory,
-                       shipment.barcode_to_path(shipment.barcodes[0]),
+                       shipment.objid_to_path(shipment.objids[0]),
                        '00000001.tif')
       info = `tiffinfo #{tiff}`
       assert_match("Artist: #{artist}", info, 'tiffinfo has custom artist tag')
@@ -138,7 +138,7 @@ class TaggerCustomTagTest < Minitest::Test
       assert stage.warnings.any? { |e| /custom\sscanner/i.match? e.to_s },
              'warns about custom scanner string'
       tiff = File.join(shipment.directory,
-                       shipment.barcode_to_path(shipment.barcodes[0]),
+                       shipment.objid_to_path(shipment.objids[0]),
                        '00000001.tif')
       info = `tiffinfo #{tiff}`
       assert_match('Make: Scans-R-Us', info,
@@ -175,7 +175,7 @@ class TaggerCustomTagTest < Minitest::Test
       assert stage.warnings.any? { |e| /custom\ssoftware/i.match? e.to_s },
              'warns about custom software string'
       tiff = File.join(shipment.directory,
-                       shipment.barcode_to_path(shipment.barcodes[0]),
+                       shipment.objid_to_path(shipment.objids[0]),
                        '00000001.tif')
       info = `tiffinfo #{tiff}`
       assert_match("Software: #{software}", info,

--- a/test/test_shipment.rb
+++ b/test/test_shipment.rb
@@ -6,7 +6,7 @@ require 'fixtures'
 require_relative '../lib/shipment'
 
 class TestShipment < Shipment # rubocop:disable Metrics/ClassLength
-  attr_reader :ordered_barcodes
+  attr_reader :ordered_objids
 
   PATH = File.join(__dir__, 'shipments').freeze
 
@@ -27,21 +27,21 @@ class TestShipment < Shipment # rubocop:disable Metrics/ClassLength
     test_shipments << name
   end
 
-  # Randomly-generated barcode that passes Luhn check
-  def self.generate_barcode(valid = true)
-    barcode = '39015' + (8.times.map { rand 10 }).join
+  # Randomly-generated objid that passes Luhn check
+  def self.generate_objid(valid = true)
+    objid = '39015' + (8.times.map { rand 10 }).join
     if valid
-      barcode + Luhn.checksum(barcode).to_s
+      objid + Luhn.checksum(objid).to_s
     else
-      barcode + ((Luhn.checksum(barcode) + 1) % 10).to_s
+      objid + ((Luhn.checksum(objid) + 1) % 10).to_s
     end
   end
 
   # Generate a test directory under test/shipments based on specification
   # spec is a string of opcodes and optional parameters
   # OPCODES
-  # [BC] create barcode directory (and make it current)
-  # [BBC] create bogus barcode directory (and make it current)
+  # [BC] create objid directory (and make it current)
+  # [BBC] create bogus objid directory (and make it current)
   # [TIF name, dest] copy TIF fixture to dest (which can be a range)
   # [F dest] create zero-length file at dest
   # [DIR] cwd to shipment directory
@@ -52,7 +52,7 @@ class TestShipment < Shipment # rubocop:disable Metrics/ClassLength
     FileUtils.rm_r(dir, force: true) if File.directory? dir
     Dir.mkdir(dir)
     super dir
-    @ordered_barcodes = []
+    @ordered_objids = []
     process_spec spec
   end
 
@@ -62,9 +62,9 @@ class TestShipment < Shipment # rubocop:disable Metrics/ClassLength
     while elements.any?
       case op = elements.shift
       when 'BC'
-        handle_barcode_op
+        handle_objid_op
       when 'BBC'
-        handle_bogus_barcode_op
+        handle_bogus_objid_op
       when 'T'
         handle_tiff_op(elements.shift, elements.shift)
       when 'J'
@@ -81,18 +81,18 @@ class TestShipment < Shipment # rubocop:disable Metrics/ClassLength
 
   private
 
-  def handle_barcode_op
-    barcode = self.class.generate_barcode(true)
-    @current_dir = File.join(@dir, barcode)
+  def handle_objid_op
+    objid = self.class.generate_objid(true)
+    @current_dir = File.join(@dir, objid)
     Dir.mkdir(@current_dir)
-    @ordered_barcodes << barcode
+    @ordered_objids << objid
   end
 
-  def handle_bogus_barcode_op
-    barcode = self.class.generate_barcode(false)
-    @current_dir = File.join(@dir, barcode)
+  def handle_bogus_objid_op
+    objid = self.class.generate_objid(false)
+    @current_dir = File.join(@dir, objid)
     Dir.mkdir(@current_dir)
-    @ordered_barcodes << barcode
+    @ordered_objids << objid
   end
 
   def handle_tiff_op(name, dest) # rubocop:disable Metrics/MethodLength
@@ -133,35 +133,35 @@ class TestShipment < Shipment # rubocop:disable Metrics/ClassLength
 end
 
 class DLXSTestShipment < TestShipment
-  # Randomly-generated DLXS id/volume/number "barcode" abcde/XXXX/YYY
-  def self.generate_barcode(valid = true)
-    barcode = [[*('a'..'z'), *('0'..'9')].sample(8).join,
-               4.times.map { rand 10 }.join,
-               3.times.map { rand 10 }.join].join('.')
-    valid ? barcode : barcode.reverse
+  # Randomly-generated DLXS id/volume/number objid abcde/XXXX/YYY
+  def self.generate_objid(valid = true)
+    objid = [[*('a'..'z'), *('0'..'9')].sample(8).join,
+             4.times.map { rand 10 }.join,
+             3.times.map { rand 10 }.join].join('.')
+    valid ? objid : objid.reverse
   end
 
-  def handle_barcode_op
-    barcode = self.class.generate_barcode(true)
-    components = barcode.split '.'
+  def handle_objid_op
+    objid = self.class.generate_objid(true)
+    components = objid.split '.'
     path = @dir
     components.each do |component|
       path = File.join(path, component)
       Dir.mkdir(path)
     end
     @current_dir = path
-    @ordered_barcodes << barcode
+    @ordered_objids << objid
   end
 
-  def handle_bogus_barcode_op
-    barcode = self.class.generate_barcode(false)
-    components = barcode.split '.'
+  def handle_bogus_objid_op
+    objid = self.class.generate_objid(false)
+    components = objid.split '.'
     path = @dir
     components.each do |component|
       path = File.join(path, component)
       Dir.mkdir(path)
     end
     @current_dir = path
-    @ordered_barcodes << barcode
+    @ordered_objids << objid
   end
 end

--- a/test/test_shipment_test.rb
+++ b/test/test_shipment_test.rb
@@ -9,55 +9,55 @@ class TestShipmentTest < Minitest::Test
     TestShipment.remove_test_shipments
   end
 
-  def test_valid_barcodes
+  def test_valid_objids
     100.times do
-      barcode = TestShipment.generate_barcode(true)
-      assert Luhn.valid?(barcode), "generate_barcode #{barcode} valid"
+      objid = TestShipment.generate_objid(true)
+      assert Luhn.valid?(objid), "generate_objid #{objid} valid"
     end
   end
 
-  def test_invalid_barcodes
+  def test_invalid_objids
     100.times do
-      barcode = TestShipment.generate_barcode(false)
-      refute Luhn.valid?(barcode), "generate_barcode #{barcode} valid"
+      objid = TestShipment.generate_objid(false)
+      refute Luhn.valid?(objid), "generate_objid #{objid} valid"
     end
   end
 
-  def test_generate_test_shipment_barcode # rubocop:disable Metrics/AbcSize
+  def test_generate_test_shipment_objid # rubocop:disable Metrics/AbcSize
     shipment = TestShipment.new(test_name, 'BC')
-    assert_equal 1, shipment.barcodes.count, 'correct number of barcodes'
+    assert_equal 1, shipment.objids.count, 'correct number of objids'
     assert File.directory?(shipment.directory), "#{test_name} is directory"
-    barcode_dir = File.join(shipment.directory,
-                            shipment.barcode_to_path(shipment.barcodes[0]))
-    assert File.directory?(barcode_dir), "#{shipment.barcodes[0]} is directory"
-    assert Luhn.valid?(shipment.barcodes[0]),
-           "barcode #{shipment.barcodes[0]} valid"
+    objid_dir = File.join(shipment.directory,
+                          shipment.objid_to_path(shipment.objids[0]))
+    assert File.directory?(objid_dir), "#{shipment.objids[0]} is directory"
+    assert Luhn.valid?(shipment.objids[0]),
+           "objid #{shipment.objids[0]} valid"
   end
 
-  def test_generate_test_shipment_bogus_barcode # rubocop:disable Metrics/AbcSize
+  def test_generate_test_shipment_bogus_objid # rubocop:disable Metrics/AbcSize
     shipment = TestShipment.new(test_name, 'BBC')
-    assert_equal 1, shipment.barcodes.count, 'correct number of barcodes'
+    assert_equal 1, shipment.objids.count, 'correct number of objids'
     assert File.directory?(shipment.directory), "#{test_name} is directory"
     assert File.directory?(File.join(shipment.directory,
-                                     shipment.barcodes[0])),
-           "#{shipment.barcodes[0]} is directory"
-    refute Luhn.valid?(shipment.barcodes[0]),
-           "barcode #{shipment.barcodes[0]} invalid"
+                                     shipment.objids[0])),
+           "#{shipment.objids[0]} is directory"
+    refute Luhn.valid?(shipment.objids[0]),
+           "objid #{shipment.objids[0]} invalid"
   end
 
   def test_generate_test_shipment_tiff_files
     shipment = TestShipment.new(test_name, 'BC T bitonal 1 F empty.txt')
-    tiff = File.join(shipment.directory, shipment.barcodes[0],
+    tiff = File.join(shipment.directory, shipment.objids[0],
                      '00000001.tif')
     assert File.exist?(tiff), '000000001.tif is copied'
-    txt = File.join(shipment.directory, shipment.barcodes[0], 'empty.txt')
+    txt = File.join(shipment.directory, shipment.objids[0], 'empty.txt')
     assert File.exist?(txt), 'empty.txt is created'
   end
 
   def test_generate_test_shipment_tiff_file_range
     shipment = TestShipment.new(test_name, 'BC T contone 1-8')
     (1..8).each do |n|
-      tiff = File.join(shipment.directory, shipment.barcodes[0],
+      tiff = File.join(shipment.directory, shipment.objids[0],
                        format('%<filename>08d.tif', { filename: n }))
       assert File.exist?(tiff), "#{tiff} in file range"
     end
@@ -65,14 +65,14 @@ class TestShipmentTest < Minitest::Test
 
   def test_generate_test_shipment_jp2_files
     shipment = TestShipment.new(test_name, 'BC J contone 1')
-    jp2 = File.join(shipment.directory, shipment.barcodes[0], '00000001.jp2')
+    jp2 = File.join(shipment.directory, shipment.objids[0], '00000001.jp2')
     assert File.exist?(jp2), '000000001.jp2 is copied'
   end
 
   def test_generate_test_shipment_jp2_file_range
     shipment = TestShipment.new(test_name, 'BC J contone 1-8')
     (1..8).each do |n|
-      jp2 = File.join(shipment.directory, shipment.barcodes[0],
+      jp2 = File.join(shipment.directory, shipment.objids[0],
                       format('%<filename>08d.jp2', { filename: n }))
       assert File.exist?(jp2), "#{jp2} in file range"
     end
@@ -104,11 +104,11 @@ class TestShipmentTest < Minitest::Test
 end
 
 class DLXSTestShipmentTest < Minitest::Test
-  def test_generate_test_shipment_dlxs_barcode # rubocop:disable Metrics/AbcSize
+  def test_generate_test_shipment_dlxs_objid # rubocop:disable Metrics/AbcSize
     shipment = DLXSTestShipment.new(test_name, 'BC')
-    assert_equal 1, shipment.ordered_barcodes.count,
-                 'correct number of ordered barcodes'
-    (id, vol, num) = shipment.ordered_barcodes[0].split '.'
+    assert_equal 1, shipment.ordered_objids.count,
+                 'correct number of ordered objids'
+    (id, vol, num) = shipment.ordered_objids[0].split '.'
     assert File.directory?(File.join(shipment.directory, id)),
            'shipment/id is directory'
     assert File.directory?(File.join(shipment.directory, id, vol)),

--- a/test/tiff_validator_test.rb
+++ b/test/tiff_validator_test.rb
@@ -51,7 +51,7 @@ class TIFFValidatorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       shipment = shipment_class.new(test_shipment.directory)
       stage = TIFFValidator.new(shipment, config: @config.merge(opts))
       tiff = File.join(shipment.directory,
-                       shipment.barcode_to_path(shipment.barcodes[0]),
+                       shipment.objid_to_path(shipment.objids[0]),
                        '00000001.tif')
       `convert #{tiff} -units PixelsPerCentimeter #{tiff}`
       stage.run!
@@ -67,7 +67,7 @@ class TIFFValidatorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       shipment = shipment_class.new(test_shipment.directory)
       stage = TIFFValidator.new(shipment, config: @config.merge(opts))
       tiff = File.join(shipment.directory,
-                       shipment.barcode_to_path(shipment.barcodes[0]),
+                       shipment.objid_to_path(shipment.objids[0]),
                        '00000001.tif')
       `tiffset -s 277 '3' #{tiff}`
       stage.run!
@@ -83,7 +83,7 @@ class TIFFValidatorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       shipment = shipment_class.new(test_shipment.directory)
       stage = TIFFValidator.new(shipment, config: @config.merge(opts))
       tiff = File.join(shipment.directory,
-                       shipment.barcode_to_path(shipment.barcodes[0]),
+                       shipment.objid_to_path(shipment.objids[0]),
                        '00000001.tif')
       `convert #{tiff} -density 100x100 -units pixelsperinch #{tiff}`
       stage.run!
@@ -99,7 +99,7 @@ class TIFFValidatorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       shipment = shipment_class.new(test_shipment.directory)
       stage = TIFFValidator.new(shipment, config: @config.merge(opts))
       tiff = File.join(shipment.directory,
-                       shipment.barcode_to_path(shipment.barcodes[0]),
+                       shipment.objid_to_path(shipment.objids[0]),
                        '00000001.tif')
       `tiffset -s 277 '2' #{tiff}`
       stage.run!
@@ -115,7 +115,7 @@ class TIFFValidatorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       shipment = shipment_class.new(test_shipment.directory)
       stage = TIFFValidator.new(shipment, config: @config.merge(opts))
       tiff = File.join(shipment.directory,
-                       shipment.barcode_to_path(shipment.barcodes[0]),
+                       shipment.objid_to_path(shipment.objids[0]),
                        '00000001.tif')
       `convert #{tiff} -density 100x100 -units pixelsperinch #{tiff}`
       stage.run!
@@ -131,7 +131,7 @@ class TIFFValidatorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       shipment = shipment_class.new(test_shipment.directory)
       stage = TIFFValidator.new(shipment, config: @config.merge(opts))
       tiff = File.join(shipment.directory,
-                       shipment.barcode_to_path(shipment.barcodes[0]),
+                       shipment.objid_to_path(shipment.objids[0]),
                        '00000001.tif')
       `/bin/echo -n 'test' > #{tiff}`
       stage.run!


### PR DESCRIPTION
This is pretty much a massive find-and-replace exercise. I did tweak the formatting of query "warnings" and "errors" command to use `printf` arguments rather than tabs.