### PR TITLE
Addresses #55 Support vendor shipments with visual QA phase

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
     - '**/Rakefile'
     - '**/config.ru'
   Exclude:
+    - 'bin/*.sh'
     - 'bin/.DS_Store'
     - 'vendor/**/*'
   SuggestExtensions: false

--- a/bin/shipment_mover.sh
+++ b/bin/shipment_mover.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+VAR_DIR="/tmp/shipment_mover"
+PREV_MD5="${VAR_DIR}/prev.md5"
+THIS_MD5="${VAR_DIR}/this.md5"
+LOCK_FILE="${VAR_DIR}/lock"
+SHIP_LIST="${VAR_DIR}/shipments.txt"
+
+
+# Where everything in process lives
+PROCESS_BASE="/mnt/ulib-chaos/Mayhem/09_Vendor_Shipments"
+# The directory examined for shipments
+BASE_DIR="${PROCESS_BASE}/01_Auto_Intake"
+# Container for 10% sample
+VENDOR_REVIEW="${PROCESS_BASE}/02_Visual_QC"
+# 10% sample goes here
+TEN_PERCENT="${VENDOR_REVIEW}/ready_for_qc"
+# Whole-shipment destination
+HT_VENDOR="${PROCESS_BASE}/03_digital_QC"
+# List of shipments processed
+LIST_DIR="${PROCESS_BASE}/05_Vendor_Lists"
+COUNT_LIST="${LIST_DIR}/auto-`date '+%Y%m%d'`.txt"
+
+
+main() {
+  stop_if_a_count_list_is_there
+  be_sure_var_dir_exists
+
+  run_if_not_already_running
+}
+
+stop_if_a_count_list_is_there() {
+  if [ -s "$COUNT_LIST" ]; then
+    exit 0
+  fi
+}
+
+be_sure_var_dir_exists() {
+  if ! [ -d "$VAR_DIR" ]; then
+    require mkdir -p "$VAR_DIR"
+    require touch "$PREV_MD5"
+  fi
+}
+
+require() {
+  if ! "$@"; then
+    error_out "command failed: $*"
+  fi
+}
+
+error_out() {
+  for i in "$@"; do
+    echo "${0}: error: $i" >&2
+  done
+  exit 1
+}
+
+run_if_not_already_running() {
+  if ! mover_is_locked; then
+    lock_shipment_mover
+    require touch "$THIS_MD5"
+    require echo -n "" > "$SHIP_LIST"
+    examine_shipments
+    [ -s "$SHIP_LIST" ] && move_shipments
+    require mv "$THIS_MD5" "$PREV_MD5"
+    unlock_shipment_mover
+  fi
+}
+
+mover_is_locked() {
+  if [ -e "$LOCK_FILE" ]; then
+    ps `cat $LOCK_FILE` > /dev/null
+  else
+    false;
+  fi
+}
+
+lock_shipment_mover() {
+  echo "$$" > "$LOCK_FILE"
+}
+
+unlock_shipment_mover() {
+  rm "$LOCK_FILE"
+}
+
+examine_shipments() {
+  require cd "$BASE_DIR"
+
+  for shipment in *; do
+    examine_if_its_a_directory "$shipment"
+  done
+}
+
+examine_if_its_a_directory() {
+  if [ -d "$1" ]; then
+    echo "$1" >> "$SHIP_LIST"
+    examine_shipment "$1"
+  fi
+}
+
+examine_shipment() {
+  find "$1" -type f | sort | while read f; do
+    md5sum "$f"
+  done >> "$THIS_MD5"
+}
+
+move_shipments() {
+  if dropoff_dir_has_changed; then
+    while read shipment; do
+      move_shipment "$shipment"
+    done < "$SHIP_LIST"
+    cd "$HT_VENDOR"
+    #chmod 664 "$COUNT_LIST"
+  fi
+}
+
+dropoff_dir_has_changed() {
+  diff "$PREV_MD5" "$THIS_MD5" > /dev/null
+  [ $? -ne 0 ]
+}
+
+move_shipment() {
+  require mkdir -p "${TEN_PERCENT}/$1"
+  pushd "${BASE_DIR}/$1" > /dev/null
+
+  for volume in *; do
+    if [ -d "$volume" ]; then
+      deal_with_volume "$1" "$volume"
+    fi
+  done
+
+  popd > /dev/null
+
+  require mv "${BASE_DIR}/$1" "$HT_VENDOR"
+}
+
+deal_with_volume() {
+  require mkdir -p "${TEN_PERCENT}/${1}/$2"
+  pagecount=`ls "$2"/0???????.??? | wc -l`
+  verify_pagecount "$2" "$pagecount"
+  print_to_count_list "$1" "$2" "$pagecount"
+  select_random_sample "$1" "$2" "$pagecount"
+}
+
+verify_pagecount() {
+  n=1
+  while [ $n -lt $2 ]; do
+    base="`printf '%s/%08d\n' "$1" "$n"`"
+
+    if ! [ -e "${base}.tif" ]; then
+      if ! [ -e "${base}.TIF" ]; then
+        if ! [ -e "${base}.jp2" ]; then
+          error_out "$shipment/$volume missing seq=$n"
+        fi
+      fi
+    fi
+    ((n+=1))
+  done
+}
+
+print_to_count_list() {
+  printf '%s\t%s\t%s\t%s\r\n' \
+    "`date '+%m/%d/%Y'`" "${1#Shipment_}" "$2" "$3" >> "$COUNT_LIST"
+}
+
+select_random_sample() {
+  total="$3"
+  size="$(((total+9)/10))"
+  max_start="$((total - size + 1))"
+  img_seq="$(((RANDOM % max_start) + 1))"
+  stop_seq="$((img_seq + size))"
+
+  while ! [ "$img_seq" = "$stop_seq" ]; do
+    move_random_page "$1" "$2" "$img_seq"
+    ((img_seq += 1))
+  done
+}
+
+move_random_page() {
+  random_dest="${TEN_PERCENT}/${1}/$2"
+  base="`printf '%s/%08d' "$2" "$3"`"
+
+  if [ -e "${base}.tif" ]; then
+    ln -it "$random_dest" "${base}.tif"
+
+  elif [ -e "${base}.TIF" ]; then
+    ln -it "$random_dest" "${base}.TIF"
+
+  elif [ -e "${base}.jp2" ]; then
+    ln -it "$random_dest" "${base}.jp2"
+  fi
+}
+
+main

--- a/config/config.dlxs.yml
+++ b/config/config.dlxs.yml
@@ -4,9 +4,9 @@ stages:
   - name: Preflight
     class: Preflight
     file: preflight
-  - name: TIFF Validator
-    class: TIFFValidator
-    file: tiff_validator
+  - name: Image Validator
+    class: ImageValidator
+    file: image_validator
   - name: Pagination Check
     class: PaginationCheck
     file: pagination_check

--- a/config/config.vendor.yml
+++ b/config/config.vendor.yml
@@ -10,12 +10,6 @@ stages:
   - name: Pagination Check
     class: PaginationCheck
     file: pagination_check
-  - name: Tagger
-    class: Tagger
-    file: tagger
-  - name: Compressor
-    class: Compressor
-    file: compressor
   - name: Postflight
     class: Postflight
     file: postflight

--- a/lib/jp2.rb
+++ b/lib/jp2.rb
@@ -1,0 +1,43 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'command'
+
+# JP2 info utility
+class JP2
+  def initialize(path)
+    @path = path
+  end
+
+  # Run tiffinfo command and return output text block
+  def info # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    cmd = "exiftool #{@path}"
+    status = Command.new(cmd).run
+    jp2info = extract_fields(status[:stdout])
+    jp2info[:cmd] = cmd
+    jp2info[:time] = status[:time]
+    jp2info[:warnings] = []
+    jp2info[:errors] = []
+    status[:stderr].chomp.split("\n").each do |err|
+      if /warning/i.match? err
+        jp2info[:warnings] << err
+      else
+        jp2info[:errors] << err
+      end
+    end
+    jp2info
+  end
+
+  private
+
+  def extract_fields(info)
+    fields = {}
+    match = info.match(/^X Resolution\s+:\s+(\d+)/)
+    fields[:x_res] = match[1].to_i unless match.nil?
+    match = info.match(/^Y Resolution\s+:\s+(\d+)/)
+    fields[:y_res] = match[1].to_i unless match.nil?
+    match = info.match(/^Resolution Unit\s+:\s+(.+)/)
+    fields[:res_unit] = match[1] unless match.nil?
+    fields
+  end
+end

--- a/lib/query_tool.rb
+++ b/lib/query_tool.rb
@@ -9,7 +9,7 @@ require 'processor'
 
 # Facility for running command-line processor/shipment queries and commands
 class QueryTool # rubocop:disable Metrics/ClassLength
-  attr_accessor :processor
+  attr_reader :processor
 
   def initialize(processor)
     @processor = processor
@@ -49,7 +49,7 @@ class QueryTool # rubocop:disable Metrics/ClassLength
       next if args.count.positive? && !args.include?(objid)
 
       puts (objid.nil? ? '(General)' : objid).bold
-      errs[objid].each_key.each do |stage|
+      errs[objid].each_key do |stage|
         puts stage.brown
         errs[objid][stage].each do |err|
           unless err.path.nil?
@@ -69,7 +69,7 @@ class QueryTool # rubocop:disable Metrics/ClassLength
       next if args.count.positive? && !args.include?(objid)
 
       puts (objid.nil? ? '(General)' : objid).bold
-      warnings[objid].each_key.each do |stage|
+      warnings[objid].each_key do |stage|
         puts stage.brown
         warnings[objid][stage].each do |err|
           unless err.path.nil?
@@ -132,7 +132,7 @@ class QueryTool # rubocop:disable Metrics/ClassLength
   def status_status(stage)
     if stage.end.nil?
       'not yet run'.italic
-    elsif stage.fatal_error?
+    elsif stage.fatal_error? || stage.error_objids.count == stage.objids.count
       'FAIL'.red
     elsif stage.errors.count.zero?
       'PASS'.green

--- a/lib/stage/image_validator.rb
+++ b/lib/stage/image_validator.rb
@@ -2,25 +2,34 @@
 # frozen_string_literal: true
 
 require 'command'
+require 'jp2'
 require 'stage'
 require 'tiff'
 
 # TIFF Validation Stage
-class TIFFValidator < Stage
+class ImageValidator < Stage
   BITONAL_RES = 600
   CONTONE_RES = 400
 
-  def run(agenda)
+  def run(agenda) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
     return unless agenda.any?
 
-    files = image_files.select { |file| agenda.include? file.objid }
-    @bar.steps = files.count
-    files.each do |image_file|
+    tiff_files = image_files.select { |file| agenda.include? file.objid }
+    jp2_files = image_files('jp2').select { |file| agenda.include? file.objid }
+    @bar.steps = tiff_files.count + jp2_files.count
+    tiff_files.each do |image_file|
       @bar.next! image_file.objid_file
       tiffinfo = run_tiffinfo image_file
       next if tiffinfo.nil?
 
-      evaluate image_file, tiffinfo
+      evaluate_tiff image_file, tiffinfo
+    end
+    jp2_files.each do |image_file|
+      @bar.next! image_file.objid_file
+      jp2info = run_jp2info image_file
+      next if jp2info.nil?
+
+      evaluate_jp2 image_file, jp2info
     end
   end
 
@@ -49,21 +58,21 @@ class TIFFValidator < Stage
   # 'Samples/Pixel' line -> spp
   # bps of 1 requires spp=1 and xres=BITONAL_RES and yres=BITONAL_RES
   # bps of 8 requires spp in [1,3,4] and xres=CONTONE_RES and yres=CONTONE_RES
-  def evaluate(image_file, info) # rubocop:disable Metrics/MethodLength
+  def evaluate_tiff(image_file, info) # rubocop:disable Metrics/MethodLength
     if info[:res_unit] != 'pixels/inch'
       image_error image_file, "must have pixels/inch, not #{info[:res_unit]}"
     end
     case info[:bps]
     when 1
-      evaluate_1_bps(image_file, info)
+      evaluate_tiff_1_bps(image_file, info)
     when 8
-      evaluate_8_bps(image_file, info)
+      evaluate_tiff_8_bps(image_file, info)
     else
       image_error image_file, "can't have BPS #{info[:bps]}"
     end
   end
 
-  def evaluate_1_bps(image_file, info)
+  def evaluate_tiff_1_bps(image_file, info)
     if info[:spp] != 1
       image_error image_file, "invalid SPP #{info[:spp]} with 1 BPS"
     end
@@ -72,7 +81,7 @@ class TIFFValidator < Stage
     image_error image_file, "#{info[:x_res]}x#{info[:y_res]} bitonal"
   end
 
-  def evaluate_8_bps(image_file, info)
+  def evaluate_tiff_8_bps(image_file, info)
     if [1, 3, 4].include? info[:spp]
       if info[:x_res] != CONTONE_RES || info[:y_res] != CONTONE_RES
         image_error image_file, "#{info[:x_res]}x#{info[:y_res]} contone"
@@ -82,7 +91,37 @@ class TIFFValidator < Stage
     end
   end
 
+  def run_jp2info(image_file) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    begin
+      info = JP2.new(image_file.path).info
+    rescue StandardError => e
+      add_error Error.new(e.message, image_file.objid, image_file.file)
+      return nil
+    end
+    log info[:cmd], info[:time]
+    info[:warnings].each do |err|
+      add_warning Error.new(err, image_file.objid, image_file.file)
+    end
+    info[:errors].each do |err|
+      add_error Error.new(err, image_file.objid, image_file.file)
+    end
+    info
+  end
+
+  def evaluate_jp2(image_file, info)
+    unless info[:res_unit] == 'inches'
+      image_error(image_file, "resolution unit '#{info[:res_unit]}'")
+    end
+    return if info[:x_res] == CONTONE_RES && info[:y_res] == CONTONE_RES
+
+    image_error image_file, "#{info[:x_res]}x#{info[:y_res]} contone"
+  end
+
   def image_error(image_file, err)
     add_error Error.new(err, image_file.objid, image_file.path)
   end
+end
+
+# Original name for this class. This is for backwards compatibility
+class TIFFValidator < ImageValidator
 end

--- a/lib/tiff.rb
+++ b/lib/tiff.rb
@@ -3,7 +3,7 @@
 
 require 'command'
 
-# TIFF Validation Stage
+# TIFF info and tagging utility
 class TIFF
   TIFFTAG_DOCUMENTNAME = 269
   TIFFTAG_MAKE = 271

--- a/rsvp.rb
+++ b/rsvp.rb
@@ -17,8 +17,8 @@ module RSVP
     ENV['HOME'] = tmpdir
     ENV['BUNDLE_GEMFILE'] ||= File.join(RSVP::APP_ROOT, 'Gemfile')
     require 'bundler/setup'
-    ENV['HOME'] = save_home
   ensure
+    ENV['HOME'] = save_home
     FileUtils.rm_rf tmpdir
   end
 

--- a/test/config/config.dlxs.yml
+++ b/test/config/config.dlxs.yml
@@ -3,9 +3,9 @@ stages:
   - name: Preflight
     class: Preflight
     file: preflight
-  - name: TIFF Validator
-    class: TIFFValidator
-    file: tiff_validator
+  - name: Image Validator
+    class: ImageValidator
+    file: image_validator
   - name: Pagination Check
     class: PaginationCheck
     file: pagination_check

--- a/test/config/config.yml
+++ b/test/config/config.yml
@@ -3,9 +3,9 @@ stages:
   - name: Preflight
     class: Preflight
     file: preflight
-  - name: TIFF Validator
-    class: TIFFValidator
-    file: tiff_validator
+  - name: Image Validator
+    class: ImageValidator
+    file: image_validator
   - name: Pagination Check
     class: PaginationCheck
     file: pagination_check

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -13,7 +13,7 @@ module Fixtures
     },
     bad_16bps: {
       file: '10_10_1_16bps_400.tif',
-      description: '16bps image that will fail TIFFValidator and Compressor'
+      description: '16bps image that will fail Image Validator and Compressor'
     }
   }.freeze
   JP2_FIXTURES = {

--- a/test/fixtures/README.txt
+++ b/test/fixtures/README.txt
@@ -1,11 +1,12 @@
 Images in this directory:
 
-
 GOOD
 ====
-10_10_1_600.tif   10x10 1bps 600ppi
-10_10_8_400.tif   10x10 8bps 400ppi
+10_10_1_600.tif              10x10 1bps 600ppi
+10_10_8_400.tif              10x10 8bps 400ppi
+10_10_8_400_compressed.tif   10x10 8bps 400ppi
+10_10_8_400.jp2              10x10 8bps 400ppi
 
 BAD
 ===
-(None yet)
+10_10_1_16bps_400.tif        10x10 16bps 400 ppi

--- a/test/image_validator_test.rb
+++ b/test/image_validator_test.rb
@@ -2,9 +2,9 @@
 # frozen_string_literal: true
 
 require 'minitest/autorun'
-require 'tiff_validator'
+require 'image_validator'
 
-class TIFFValidatorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
+class ImageValidatorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
   def setup
     @config = Config.new({ no_progress: true })
   end
@@ -17,7 +17,7 @@ class TIFFValidatorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
     test_proc = proc { |shipment_class, test_shipment_class, dir, opts|
       test_shipment = test_shipment_class.new(dir)
       shipment = shipment_class.new(test_shipment.directory)
-      stage = TIFFValidator.new(shipment, config: @config.merge(opts))
+      stage = ImageValidator.new(shipment, config: @config.merge(opts))
       refute_nil stage, 'stage successfully created'
     }
     generate_tests 'new', test_proc
@@ -27,7 +27,7 @@ class TIFFValidatorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
     test_proc = proc { |shipment_class, test_shipment_class, dir, opts|
       test_shipment = test_shipment_class.new(dir, 'BC T bitonal 1 T contone 2')
       shipment = shipment_class.new(test_shipment.directory)
-      stage = TIFFValidator.new(shipment, config: @config.merge(opts))
+      stage = ImageValidator.new(shipment, config: @config.merge(opts))
       stage.run!
       assert_equal(0, stage.errors.count, 'stage runs without errors')
     }
@@ -38,7 +38,7 @@ class TIFFValidatorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
     test_proc = proc { |shipment_class, test_shipment_class, dir, opts|
       test_shipment = test_shipment_class.new(dir, 'BC T bad_16bps 1')
       shipment = shipment_class.new(test_shipment.directory)
-      stage = TIFFValidator.new(shipment, config: @config.merge(opts))
+      stage = ImageValidator.new(shipment, config: @config.merge(opts))
       stage.run!
       assert_equal(1, stage.errors.count, '16bps TIFF rejected')
     }
@@ -49,7 +49,7 @@ class TIFFValidatorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
     test_proc = proc { |shipment_class, test_shipment_class, dir, opts|
       test_shipment = test_shipment_class.new(dir, 'BC T bitonal 1')
       shipment = shipment_class.new(test_shipment.directory)
-      stage = TIFFValidator.new(shipment, config: @config.merge(opts))
+      stage = ImageValidator.new(shipment, config: @config.merge(opts))
       tiff = File.join(shipment.directory,
                        shipment.objid_to_path(shipment.objids[0]),
                        '00000001.tif')
@@ -65,7 +65,7 @@ class TIFFValidatorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
     test_proc = proc { |shipment_class, test_shipment_class, dir, opts|
       test_shipment = test_shipment_class.new(dir, 'BC T bitonal 1')
       shipment = shipment_class.new(test_shipment.directory)
-      stage = TIFFValidator.new(shipment, config: @config.merge(opts))
+      stage = ImageValidator.new(shipment, config: @config.merge(opts))
       tiff = File.join(shipment.directory,
                        shipment.objid_to_path(shipment.objids[0]),
                        '00000001.tif')
@@ -81,7 +81,7 @@ class TIFFValidatorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
     test_proc = proc { |shipment_class, test_shipment_class, dir, opts|
       test_shipment = test_shipment_class.new(dir, 'BC T bitonal 1')
       shipment = shipment_class.new(test_shipment.directory)
-      stage = TIFFValidator.new(shipment, config: @config.merge(opts))
+      stage = ImageValidator.new(shipment, config: @config.merge(opts))
       tiff = File.join(shipment.directory,
                        shipment.objid_to_path(shipment.objids[0]),
                        '00000001.tif')
@@ -97,7 +97,7 @@ class TIFFValidatorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
     test_proc = proc { |shipment_class, test_shipment_class, dir, opts|
       test_shipment = test_shipment_class.new(dir, 'BC T contone 1')
       shipment = shipment_class.new(test_shipment.directory)
-      stage = TIFFValidator.new(shipment, config: @config.merge(opts))
+      stage = ImageValidator.new(shipment, config: @config.merge(opts))
       tiff = File.join(shipment.directory,
                        shipment.objid_to_path(shipment.objids[0]),
                        '00000001.tif')
@@ -113,7 +113,7 @@ class TIFFValidatorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
     test_proc = proc { |shipment_class, test_shipment_class, dir, opts|
       test_shipment = test_shipment_class.new(dir, 'BC T contone 1')
       shipment = shipment_class.new(test_shipment.directory)
-      stage = TIFFValidator.new(shipment, config: @config.merge(opts))
+      stage = ImageValidator.new(shipment, config: @config.merge(opts))
       tiff = File.join(shipment.directory,
                        shipment.objid_to_path(shipment.objids[0]),
                        '00000001.tif')
@@ -129,7 +129,7 @@ class TIFFValidatorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
     test_proc = proc { |shipment_class, test_shipment_class, dir, opts|
       test_shipment = test_shipment_class.new(dir, 'BC T contone 1')
       shipment = shipment_class.new(test_shipment.directory)
-      stage = TIFFValidator.new(shipment, config: @config.merge(opts))
+      stage = ImageValidator.new(shipment, config: @config.merge(opts))
       tiff = File.join(shipment.directory,
                        shipment.objid_to_path(shipment.objids[0]),
                        '00000001.tif')

--- a/test/jp2_test.rb
+++ b/test/jp2_test.rb
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'jp2'
+
+class TIFFTest < Minitest::Test
+  def test_new
+    shipment = TestShipment.new(test_name, 'BC J contone 1')
+    jp2 = JP2.new(shipment.image_files.first.path)
+    refute_nil jp2, 'JP2 is not nil'
+  end
+
+  def test_info # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    shipment = TestShipment.new(test_name, 'BC J contone 1')
+    jp2 = JP2.new(shipment.image_files.first.path)
+    info = jp2.info
+    assert_instance_of Hash, info
+    assert_instance_of Array, info[:warnings]
+    assert_empty info[:warnings]
+    assert_instance_of Array, info[:errors]
+    assert_empty info[:errors]
+    assert_instance_of Integer, info[:x_res]
+    assert_instance_of Integer, info[:y_res]
+    assert_instance_of String, info[:res_unit]
+  end
+end

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -63,8 +63,8 @@ class ProcessorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       end
       errs = processor.errors['Preflight'][processor.shipment.objids[0]]
       warnings = processor.warnings['Preflight'][processor.shipment.objids[0]]
-      assert errs.any? { |e| /no.TIFF/i.match? e.to_s },
-             'Preflight fails with no TIFFs error'
+      assert errs.any? { |e| /no.image.files/.match? e.to_s },
+             'Preflight fails with no images error'
       assert warnings.any? { |e| /\.DS_Store/.match? e.to_s },
              'Preflight warns about .DS_Store'
     }
@@ -95,7 +95,7 @@ class ProcessorTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       end
       processor.write_status_file
       processor = Processor.new(test_shipment.directory, opts.merge(@options))
-      errs = processor.errors['TIFF Validator'][processor.shipment.objids[0]]
+      errs = processor.errors['Image Validator'][processor.shipment.objids[0]]
       assert_kind_of Error, errs[0],
                      'Error class reconstituted from status.json'
     }

--- a/test/tiff_test.rb
+++ b/test/tiff_test.rb
@@ -35,6 +35,16 @@ class TIFFTest < Minitest::Test
     assert_nil info[:software]
   end
 
+  def test_info_fail
+    shipment = TestShipment.new(test_name, 'BC F bogus_file')
+    tiff = TIFF.new(File.join(shipment.directory,
+                              shipment.objid_to_path(shipment.objids.first),
+                              'bogus_file'))
+    assert_raises(StandardError, 'raises StandardError on bogus file') do
+      tiff.info
+    end
+  end
+
   def test_set
     shipment = TestShipment.new(test_name, 'BC T contone 1')
     tiff = TIFF.new(shipment.image_files.first.path)


### PR DESCRIPTION
- Add modified `bin/shipment_mover.sh` script
- Add very bare-bones rudimentary JP2 class
- Rename `TIFFValidator` to `ImageValidator` since it's also checking JP2 files
- Add `vendor` config profile
- Minor fixups for issues exposed by `rubycritic`